### PR TITLE
積載容量と補給品バランスを修正

### DIFF
--- a/game.js
+++ b/game.js
@@ -5,7 +5,7 @@ const gameState = {
     inventory: {},
     ship: {
         name: 'カラベル船',
-        capacity: 50,
+        capacity: 100,
         speed: 1,
         crew: 20
     },
@@ -159,7 +159,7 @@ const portPrices = {
 const shipUpgrades = [
     {
         name: 'カラベル船',
-        capacity: 50,
+        capacity: 100,
         speed: 1,
         cost: 0,
         crew: 20,
@@ -167,7 +167,7 @@ const shipUpgrades = [
     },
     {
         name: 'キャラック船',
-        capacity: 100,
+        capacity: 200,
         speed: 1.2,
         cost: 5000,
         crew: 40,
@@ -175,7 +175,7 @@ const shipUpgrades = [
     },
     {
         name: 'ガレオン船',
-        capacity: 150,
+        capacity: 300,
         speed: 1.5,
         cost: 15000,
         crew: 60,
@@ -183,7 +183,7 @@ const shipUpgrades = [
     },
     {
         name: '東インド会社船',
-        capacity: 250,
+        capacity: 500,
         speed: 2,
         cost: 50000,
         crew: 100,
@@ -746,8 +746,8 @@ function getRandomWeather() {
 function calculateRequiredSupplies(days) {
     const crew = gameState.ship.crew;
     return {
-        food: Math.ceil(crew * days * 1.5), // 1.5x for safety margin
-        water: Math.ceil(crew * days * 1.5)
+        food: Math.ceil(crew * days * 1.0), // 1 unit per crew per day
+        water: Math.ceil(crew * days * 1.0)
     };
 }
 


### PR DESCRIPTION
問題:
- カラベル船(容量50)ではセビリアへの航海に必要な補給品(120)が積めない
- 最初の航海が物理的に不可能な状態だった

修正内容:
1. 補給品の計算式を調整 (安全マージン 1.5 → 1.0)
   - 1人1日あたり: 食料1、水1
2. 全船の積載容量を2倍に増加
   - カラベル船: 50 → 100
   - キャラック船: 100 → 200
   - ガレオン船: 150 → 300
   - 東インド会社船: 250 → 500

結果:
- セビリア(2日、乗組員20人): 必要80 < 積載100 ✅
- 余裕の20枠で商品も積載可能

🤖 Generated with [Claude Code](https://claude.com/claude-code)