### PR TITLE
利益計算から旅費システムの名残(0.8倍)を削除

### DIFF
--- a/game.js
+++ b/game.js
@@ -369,7 +369,7 @@ function calculateProfitForPort(destinationPortId) {
         const buyPrice = Math.round(good.basePrice * portPrices[currentPort][goodId] * 0.95);
 
         // Calculate sell price at destination port
-        const sellPrice = Math.round(good.basePrice * portPrices[destinationPortId][goodId] * 0.8 * 0.95);
+        const sellPrice = Math.round(good.basePrice * portPrices[destinationPortId][goodId] * 0.95);
 
         const profitPerUnit = sellPrice - buyPrice;
         const profitMargin = buyPrice > 0 ? (profitPerUnit / buyPrice) * 100 : 0;


### PR DESCRIPTION
旅費が削除されたにもかかわらず、calculateProfitForPort()関数の
売却価格計算に0.8倍が残っていたため、利益が実際より低く
見積もられ、初期状態で「行ける&儲かる港」が表示されない
問題が発生していました。

この0.8倍を削除することで、正確な利益計算が行われ、
初期状態から適切に儲かる港が表示されるようになります。