### PR TITLE
水と食料の価格を削減してゲームバランスを改善

### DIFF
--- a/game.js
+++ b/game.js
@@ -100,9 +100,9 @@ const goods = {
     porcelain: { name: '陶器', emoji: '🏺', basePrice: 120 },
     tea: { name: '茶', emoji: '🍵', basePrice: 100 },
     silver: { name: '銀', emoji: '💍', basePrice: 250 },
-    // Essential supplies
-    food: { name: '食糧', emoji: '🍖', basePrice: 5 },
-    water: { name: '水', emoji: '💧', basePrice: 3 }
+    // Essential supplies (reduced prices for better game balance)
+    food: { name: '食糧', emoji: '🍖', basePrice: 2 },
+    water: { name: '水', emoji: '💧', basePrice: 1 }
 };
 
 // Weather system


### PR DESCRIPTION
問題:
- 初期資金1000Gでリスボン↔セビリアを往復すると物資コストで資金が枯渇
- 物資コスト(修正前): 約320G/回 × 3回 = 960G
- 商品売買の資金がほとんど残らず、ゲームが詰む

修正内容:
- 食料の基本価格: 5G → 2G (60%削減)
- 水の基本価格: 3G → 1G (67%削減)

効果:
- 物資コスト(修正後): 約120G/回 (食料80G + 水40G)
- 3回往復でも360Gで済み、640Gを商品購入に使用可能
- 初期資金から利益を積み重ねられるバランスに改善