### PR TITLE
Check game balance and difficulty progression

### DIFF
--- a/game.js
+++ b/game.js
@@ -206,19 +206,8 @@ function initializePortInventory() {
         const maxStock = inventorySettings[portSize].maxStock;
 
         for (const goodId in goods) {
-            // Water and food are more abundant in larger cities
-            if (goodId === 'water' || goodId === 'food') {
-                // Small ports have limited supplies (30% of max)
-                // Medium and larger ports have full supplies
-                if (portSize === 'small') {
-                    portInventory[portId][goodId] = Math.round(maxStock * 0.3);
-                } else {
-                    portInventory[portId][goodId] = maxStock;
-                }
-            } else {
-                // Other goods start at max stock
-                portInventory[portId][goodId] = maxStock;
-            }
+            // All ports now have full supplies of water and food for better game balance
+            portInventory[portId][goodId] = maxStock;
         }
     }
 }
@@ -316,22 +305,11 @@ function loadGame() {
                     const portSize = ports[portId].size;
                     const maxStock = inventorySettings[portSize].maxStock;
 
-                    // Ensure water and food have proper initial values
+                    // Ensure all goods have proper initial values
                     for (const goodId in goods) {
-                        if (goodId === 'water' || goodId === 'food') {
-                            // If water or food is missing or 0, reset to initial value
-                            if (!portInventory[portId][goodId] || portInventory[portId][goodId] === 0) {
-                                if (portSize === 'small') {
-                                    portInventory[portId][goodId] = Math.round(maxStock * 0.3);
-                                } else {
-                                    portInventory[portId][goodId] = maxStock;
-                                }
-                            }
-                        } else {
-                            // Initialize other goods if missing
-                            if (!portInventory[portId][goodId]) {
-                                portInventory[portId][goodId] = maxStock;
-                            }
+                        // Initialize missing goods with max stock
+                        if (!portInventory[portId][goodId] || portInventory[portId][goodId] === 0) {
+                            portInventory[portId][goodId] = maxStock;
                         }
                     }
                 }
@@ -1012,8 +990,8 @@ function getRandomWeather() {
 function calculateRequiredSupplies(days) {
     const crew = gameState.ship.crew;
     return {
-        food: Math.ceil(crew * days * 1.0), // 1 unit per crew per day
-        water: Math.ceil(crew * days * 1.0)
+        food: Math.ceil(crew * days * 0.08), // 0.08 units per crew per day (reduced for better game balance)
+        water: Math.ceil(crew * days * 0.08)
     };
 }
 


### PR DESCRIPTION
## 修正内容

### 1. 物資消費量を大幅に削減 (1.0 → 0.08倍)
- 以前: 乗組員1人あたり1日1個の食糧・水が必要
- 修正後: 乗組員1人あたり1日0.08個に削減
- これにより遠距離航路（長崎など）への到達が可能に

### 2. 全港の食糧・水在庫を統一
- 以前: 小規模港（長崎）は在庫が30%（9個）のみ
- 修正後: すべての港でmaxStock分の在庫を確保
- 長崎に到着しても帰路の物資が調達可能に

## 修正前の問題

### 問題1: 長崎への到達が不可能
どの船でも物資の必要量が積載量を超過：
- カラベル船: 1200個必要 > 積載量100
- キャラック船: 2000個必要 > 積載量200
- ガレオン船: 2400個必要 > 積載量300
- 東インド会社船: 3000個必要 > 積載量500

### 問題2: 長崎からの脱出が不可能
- 長崎の食糧・水在庫: わずか9個
- 最短ルート（マラッカ）でも400個の物資が必要
- 完全に詰む状態

## 修正後の改善

### カラベル船（初期船）の場合
- リスボン→長崎（30日）: 食糧48個 + 水48個 = 96個
- 積載量100で到達可能！

### 東インド会社船の場合
- リスボン→長崎（15日）: 食糧120個 + 水120個 = 240個
- 積載量500で余裕を持って到達可能

これにより全ての港へのアクセスが可能になり、
プレイヤーが途中で詰むことがなくなりました。