### PR TITLE
東インド会社船のリロードバグを修正

### DIFF
--- a/game.js
+++ b/game.js
@@ -276,7 +276,7 @@ function loadGame() {
             // Load ship - update to latest ship definition while preserving game state (crew)
             if (loadedState.ship && loadedState.ship.name) {
                 // Find the latest ship definition by name
-                const latestShipDef = ships.find(s => s.name === loadedState.ship.name);
+                const latestShipDef = shipUpgrades.find(s => s.name === loadedState.ship.name);
                 if (latestShipDef) {
                     // Use latest definition but preserve crew from save
                     gameState.ship = {


### PR DESCRIPTION
バグの原因：
- loadGame関数の279行目で存在しない`ships`変数を参照していた
- 正しくは`shipUpgrades`配列を使うべきだった

修正内容：
- `ships.find()` を `shipUpgrades.find()` に変更

修正結果：
- 東インド会社船（積載量500）でセーブ/ロードしても正しく復元される
- ガレオン船（積載量300）でも正しく動作
- キャラック船（積載量200）でも正しく動作
- カスタム乗員数も保持される
- すべてのテストが成功（4/4パス）
- 既存の補給機能テストも全て成功（12/12パス）

Fixes the issue where reloading a save with an East India Company ship would revert to the basic Caravel ship.