### PR TITLE
Fix autopilot feature causing negative assets

### DIFF
--- a/game.js
+++ b/game.js
@@ -2118,9 +2118,15 @@ function findBestTrade() {
             
             // Net benefit of traveling to sell there
             const netBenefit = destSellValue - bestSellValue - supplyCost;
-            
-            // Only travel if we have enough money for supplies AND net benefit is significant
-            if (gameState.gold >= supplyCost && netBenefit > bestSellValue * AUTOPILOT_CONFIG.PROFIT_IMPROVEMENT_RATIO && destSellValue > bestSellPotential) {
+
+            // Only travel if:
+            // 1. We have enough money for supplies + safety reserve
+            // 2. Net benefit exceeds supply cost (travel must be profitable)
+            // 3. Net benefit is significant (at least 10% improvement)
+            if (gameState.gold >= supplyCost + AUTOPILOT_CONFIG.SAFETY_RESERVE &&
+                netBenefit > supplyCost &&
+                netBenefit > bestSellValue * AUTOPILOT_CONFIG.PROFIT_IMPROVEMENT_RATIO &&
+                destSellValue > bestSellPotential) {
                 bestSellPotential = destSellValue;
                 bestSellPort = destPortId;
                 bestSupplyCost = supplyCost;


### PR DESCRIPTION
This fixes the issue where autopilot could result in large losses (e.g., -4260G) due to repeated unprofitable travels.

Root cause:
- When holding goods, autopilot would travel to ports with higher sell prices even when the net benefit didn't justify the supply cost
- This led to multiple trips accumulating supply costs without sufficient profit gains
- Safety reserve was not considered when deciding to travel

Changes:
1. Added safety reserve check: Only travel if we can afford supply cost + 100G safety reserve
2. Added profitability check: Only travel if net benefit exceeds the supply cost itself (travel must be worth the expense)
3. Kept existing 10% improvement threshold for significance

Impact:
- Prevents unprofitable travels that accumulate supply costs
- Encourages selling at current port when travel benefit is marginal
- Maintains conservative cash reserves for stability

Testing:
- All existing tests pass
- Balance simulation shows no negative profits