### PR TITLE
Maximize autopilot profits and add hourly scheduling

### DIFF
--- a/index.html
+++ b/index.html
@@ -87,9 +87,9 @@
                             <span id="autopilot-timer"></span>
                         </div>
                         <div style="display: flex; gap: 10px; margin-bottom: 10px;">
-                            <input type="number" id="autopilot-duration" min="1" max="180" value="60" 
+                            <input type="number" id="autopilot-duration" min="1" max="24" value="1"
                                    style="flex: 1; padding: 8px; border: 2px solid #3498db; border-radius: 5px; font-size: 1em;">
-                            <span style="display: flex; align-items: center; font-weight: bold;">分</span>
+                            <span style="display: flex; align-items: center; font-weight: bold;">時間</span>
                         </div>
                         <button id="autopilot-toggle" class="btn btn-primary" onclick="toggleAutopilot()" 
                                 style="width: 100%; padding: 10px; font-size: 1em;">


### PR DESCRIPTION
- 利益最大化のためのアルゴリズム改善:
  - 貨物・資金利用率: 70% → 90% に引き上げ
  - 最低利益しきい値: 100G → 50G に引き下げ
  - 移動判断の利益改善率: 10% → 5% に引き下げ
  - 最大取引量: 50 → 100 に増加
  - 安全保留金: 100G → 50G に削減

- 時間単位での実行設定に変更:
  - 1-180分 → 1-24時間の設定に変更
  - UIを分単位から時間単位に変更
  - 残り時間表示を「X時間Y分」形式に改善
  - レポート表示も時間単位に対応

これらの変更により、オートパイロットがより積極的に取引を行い、
より長時間の自動実行が可能になります。