### PR TITLE
Debug autopilot earnings lower than manual mode

### DIFF
--- a/game.js
+++ b/game.js
@@ -36,7 +36,7 @@ const gameState = {
 // Autopilot configuration constants
 const AUTOPILOT_CONFIG = {
     SAFETY_RESERVE: 50,            // Reserve gold for emergencies (reduced for more aggressive trading)
-    CARGO_UTILIZATION_RATIO: 0.9,  // Use 90% of available cargo/money for trading (increased from 70%)
+    CARGO_UTILIZATION_RATIO: 0.98, // Use 98% of available cargo/money for trading (increased from 90% to maximize profit)
     MINIMUM_PROFIT_THRESHOLD: 50,  // Minimum expected profit to execute trade (reduced from 100 to catch more opportunities)
     PROFIT_IMPROVEMENT_RATIO: 0.05,// Require 5% better profit to travel for selling (reduced from 10% for more aggressive movement)
     MINIMUM_PURCHASE_MULTIPLIER: 5,// Must afford at least 5 units to buy


### PR DESCRIPTION
問題：
- オートパイロットが手動プレイより利益が少ない
- 原因：積荷スペースの90%しか使用していなかった

変更：
- CARGO_UTILIZATION_RATIO: 0.9 → 0.98
- これにより積荷をほぼ満タンに積めるようになり、手動プレイと同等の利益を得られる
- 2%の余裕は予期しない状況への安全マージン

影響：
- オートパイロット実行時の1回あたりの取引量が約8%増加
- 利益効率が大幅に向上