### PR TITLE
Fix autopilot trading completion issue

### DIFF
--- a/src/services/autopilot-service.js
+++ b/src/services/autopilot-service.js
@@ -11,6 +11,9 @@ let updateAll;
 let saveGame;
 let showAutopilotReport;
 
+// Timer for periodic UI updates
+let autopilotTimerId = null;
+
 // Set UI callback functions (call this from main game initialization)
 export function setUICallbacks(updateAllFn, saveGameFn, showAutopilotReportFn) {
     updateAll = updateAllFn;
@@ -49,6 +52,9 @@ export function startAutopilot(durationHours) {
 
     saveGame();
     updateAll();
+
+    // Start periodic timer update
+    startAutopilotTimer();
 
     // Start autopilot loop
     runAutopilotCycle();
@@ -90,6 +96,10 @@ export function stopAutopilot() {
     }
 
     gameState.autopilotActive = false;
+
+    // Stop periodic timer update
+    stopAutopilotTimer();
+
     const report = generateAutopilotReport();
     showAutopilotReport(report);
 
@@ -112,6 +122,42 @@ export function checkAutopilotTimeout() {
     }
 
     return false;
+}
+
+// Start periodic timer updates
+export function startAutopilotTimer() {
+    // Clear any existing timer
+    stopAutopilotTimer();
+
+    // Update timer display every second
+    const updateTimer = () => {
+        if (!gameState.autopilotActive) {
+            stopAutopilotTimer();
+            return;
+        }
+
+        // Check if autopilot should stop
+        if (checkAutopilotTimeout()) {
+            return;
+        }
+
+        // Update UI
+        updateAll();
+
+        // Schedule next update
+        autopilotTimerId = setTimeout(updateTimer, 1000);
+    };
+
+    // Start the timer
+    autopilotTimerId = setTimeout(updateTimer, 1000);
+}
+
+// Stop periodic timer updates
+export function stopAutopilotTimer() {
+    if (autopilotTimerId !== null) {
+        clearTimeout(autopilotTimerId);
+        autopilotTimerId = null;
+    }
 }
 
 // Run a single autopilot cycle
@@ -897,6 +943,8 @@ if (typeof module !== 'undefined' && module.exports) {
         generateAutopilotReport,
         setUICallbacks,
         getRemainingAutopilotTime,
-        calculateTimeEfficiency
+        calculateTimeEfficiency,
+        startAutopilotTimer,
+        stopAutopilotTimer
     };
 }

--- a/src/services/save-service.js
+++ b/src/services/save-service.js
@@ -3,7 +3,7 @@ import { ports, shipUpgrades, inventorySettings, goods } from '../core/constants
 import { addLog } from '../utils/logger.js';
 import { initializePortInventory, refreshPortInventory } from './port-service.js';
 import { consumeSupplies } from './supply-service.js';
-import { simulateOfflineAutopilot, runAutopilotCycle } from './autopilot-service.js';
+import { simulateOfflineAutopilot, runAutopilotCycle, startAutopilotTimer } from './autopilot-service.js';
 
 // NOTE: These UI functions need to be imported from game.js or a UI module
 // For now, they are expected to be available in the global scope or passed as parameters
@@ -274,6 +274,7 @@ function checkAndUpdateAutopilotProgress() {
         // If autopilot is still active after simulation, resume the loop
         if (gameState.autopilotActive) {
             addLog(`🤖 オートパイロットを再開しました (残り: ${Math.round(gameState.autopilotDurationMinutes - elapsedMinutes)}分)`);
+            startAutopilotTimer();
             runAutopilotCycle();
         }
 


### PR DESCRIPTION
問題:
- タイマー表示が更新されず、残り時間が減っているように見えなかった
- 「まもなく完了...」と表示されても、実際の終了まで最大3秒のラグがあった
- ユーザーが「終了していない」と感じる原因となっていた

修正内容:
- 1秒ごとにタイマー表示を更新する仕組みを追加
- タイマー更新時にリアルタイムで終了判定を実行
- ページ再読み込み時にもタイマーが自動再開されるように修正
- 航海機能と同じアプローチで実装（setTimeoutによる定期更新）

これにより、オートパイロットが時間通りに終了し、タイマーもリアルタイムで更新されるようになりました。