### PR TITLE
Fix autopilot status display bug

### DIFF
--- a/src/services/autopilot-service.js
+++ b/src/services/autopilot-service.js
@@ -131,13 +131,17 @@ export function startAutopilotTimer() {
 
     // Update timer display every second
     const updateTimer = () => {
-        if (!gameState.autopilotActive) {
-            stopAutopilotTimer();
+        // Check if autopilot should stop FIRST (before checking autopilotActive)
+        // This ensures that timeout is checked even if the flag hasn't been updated yet
+        if (gameState.autopilotActive && checkAutopilotTimeout()) {
+            // stopAutopilot() was called, which sets autopilotActive to false
+            // and calls stopAutopilotTimer(), so we don't need to schedule another update
             return;
         }
 
-        // Check if autopilot should stop
-        if (checkAutopilotTimeout()) {
+        // If autopilot is no longer active, stop the timer
+        if (!gameState.autopilotActive) {
+            stopAutopilotTimer();
             return;
         }
 

--- a/src/ui/autopilot-ui.js
+++ b/src/ui/autopilot-ui.js
@@ -98,18 +98,24 @@ export function updateAutopilotUI() {
         durationInput.disabled = true;
 
         const elapsed = Date.now() - gameState.autopilotStartTime;
-        const elapsedMinutes = Math.floor(elapsed / 60000);
+        const elapsedMinutes = elapsed / 60000;
         const remainingMinutes = gameState.autopilotDurationMinutes - elapsedMinutes;
 
         if (remainingMinutes > 0) {
-            const hours = Math.floor(remainingMinutes / 60);
-            const minutes = remainingMinutes % 60;
+            const displayMinutes = Math.floor(remainingMinutes);
+            const hours = Math.floor(displayMinutes / 60);
+            const minutes = displayMinutes % 60;
+            const seconds = Math.floor((remainingMinutes - displayMinutes) * 60);
+
             if (hours > 0) {
-                timerSpan.textContent = `⏱️ 残り: ${hours}時間${minutes}分`;
+                timerSpan.textContent = `⏱️ 残り: ${hours}時間${minutes}分${seconds}秒`;
+            } else if (minutes > 0) {
+                timerSpan.textContent = `⏱️ 残り: ${minutes}分${seconds}秒`;
             } else {
-                timerSpan.textContent = `⏱️ 残り: ${minutes}分`;
+                timerSpan.textContent = `⏱️ 残り: ${seconds}秒`;
             }
         } else {
+            // Time is up - this should trigger stopAutopilot very soon
             timerSpan.textContent = '⏱️ まもなく完了...';
         }
     } else {


### PR DESCRIPTION
- タイマー更新時にタイムアウトチェックを最優先で実行するように変更
- UI表示で秒単位の残り時間を表示し、より正確な進捗を確認可能に
- 時間切れ後の自動停止がより確実に動作するよう処理順序を最適化

この修正により、オートパイロットが時間通りに終了し、手動で停止ボタンを
押す必要がなくなります。