### PR TITLE
オートパイロットの自動停止をより明確に改善

### DIFF
--- a/src/services/autopilot-service.js
+++ b/src/services/autopilot-service.js
@@ -61,7 +61,7 @@ export function startAutopilot(durationHours) {
 }
 
 // Stop autopilot mode
-export function stopAutopilot() {
+export function stopAutopilot(isAutoStop = false) {
     if (!gameState.autopilotActive) {
         return;
     }
@@ -100,6 +100,13 @@ export function stopAutopilot() {
     // Stop periodic timer update
     stopAutopilotTimer();
 
+    // Log appropriate message
+    if (isAutoStop) {
+        addLog(`✅ オートパイロットが時間切れで自動停止しました`);
+    } else {
+        addLog(`⏹️ オートパイロットを手動停止しました`);
+    }
+
     const report = generateAutopilotReport();
     showAutopilotReport(report);
 
@@ -117,7 +124,8 @@ export function checkAutopilotTimeout() {
     const elapsedMinutes = elapsed / 60000;
 
     if (elapsedMinutes >= gameState.autopilotDurationMinutes) {
-        stopAutopilot();
+        addLog(`⏰ オートパイロット実行時間が終了しました`);
+        stopAutopilot(true); // Auto-stop
         return true;
     }
 

--- a/src/ui/autopilot-ui.js
+++ b/src/ui/autopilot-ui.js
@@ -109,20 +109,36 @@ export function updateAutopilotUI() {
 
             if (hours > 0) {
                 timerSpan.textContent = `⏱️ 残り: ${hours}時間${minutes}分${seconds}秒`;
+                timerSpan.style.color = '';
+                timerSpan.style.fontWeight = '';
             } else if (minutes > 0) {
                 timerSpan.textContent = `⏱️ 残り: ${minutes}分${seconds}秒`;
-            } else {
+                timerSpan.style.color = '';
+                timerSpan.style.fontWeight = '';
+            } else if (seconds > 10) {
                 timerSpan.textContent = `⏱️ 残り: ${seconds}秒`;
+                timerSpan.style.color = '';
+                timerSpan.style.fontWeight = '';
+            } else {
+                // Last 10 seconds - make it more noticeable
+                timerSpan.textContent = `⏱️ まもなく自動停止... ${seconds}秒`;
+                timerSpan.style.color = '#ff9800';
+                timerSpan.style.fontWeight = 'bold';
             }
         } else {
-            // Time is up - this should trigger stopAutopilot very soon
-            timerSpan.textContent = '⏱️ まもなく完了...';
+            // Time is up - autopilot will auto-stop within 1 second
+            timerSpan.textContent = '⏱️ 自動停止中...';
+            timerSpan.style.color = '#ff9800';
+            timerSpan.style.fontWeight = 'bold';
         }
     } else {
         toggleBtn.textContent = '🤖 開始';
         toggleBtn.className = 'btn btn-primary';
         durationInput.disabled = false;
         timerSpan.textContent = '';
+        // Reset timer style
+        timerSpan.style.color = '';
+        timerSpan.style.fontWeight = '';
     }
 }
 


### PR DESCRIPTION
ユーザーが手動で停止ボタンを押さなくても、時間切れ時に自動停止することをより明確にするため、以下の改善を実施：

変更内容:
- stopAutopilot()に自動停止フラグを追加し、手動停止と自動停止を区別
- 自動停止時に「✅ オートパイロットが時間切れで自動停止しました」とログ出力
- 手動停止時に「⏹️ オートパイロットを手動停止しました」とログ出力
- checkAutopilotTimeout()で時間切れ時に「⏰ オートパイロット実行時間が終了しました」と通知
- UIで残り10秒を切ると「まもなく自動停止...」とオレンジ色でボールド表示
- 時間切れ時に「自動停止中...」と明確に表示

効果:
- ユーザーが何も操作しなくても自動停止することが明確になる
- 自動停止のタイミングが視覚的にわかりやすくなる
- 手動停止と自動停止の違いがログで識別できる