### PR TITLE
Set up tests without CommonJS modules

### DIFF
--- a/game.js
+++ b/game.js
@@ -1,8 +1,8 @@
-// CommonJS wrapper for tests
-// This file provides backward compatibility for test files
+// ESM wrapper for tests
+// This file provides exports for test files
 
-const { gameState, portInventory } = require('./src/core/game-state.js');
-const {
+export { gameState, portInventory } from './src/core/game-state.js';
+export {
     ports,
     goods,
     portDistances,
@@ -10,25 +10,25 @@ const {
     inventorySettings,
     shipUpgrades,
     getSeaRoute
-} = require('./src/core/constants.js');
+} from './src/core/constants.js';
 
-const {
+export {
     initializePortInventory,
     refreshPortInventory,
     getPortStock,
     reducePortStock
-} = require('./src/services/port-service.js');
+} from './src/services/port-service.js';
 
-const {
+export {
     calculateRequiredSupplies,
     hasEnoughSupplies,
     consumeSupplies,
     buySupply,
     autoSupplyForVoyage,
     calculateSupplyCost
-} = require('./src/services/supply-service.js');
+} from './src/services/supply-service.js';
 
-const {
+export {
     getCurrentPortName,
     getCargoUsed,
     getCargoSpace,
@@ -37,55 +37,19 @@ const {
     getRecommendedGoods,
     isProfitable,
     canAffordVoyage
-} = require('./src/utils/calculations.js');
+} from './src/utils/calculations.js';
 
-const {
+export {
     saveGame,
     loadGame
-} = require('./src/services/save-service.js');
+} from './src/services/save-service.js';
 
-const {
+export {
     initializeVoyageMap,
     updateShipPosition,
     selectDestination
-} = require('./src/services/voyage-service.js');
+} from './src/services/voyage-service.js';
 
-const {
+export {
     findBestTrade
-} = require('./src/services/autopilot-service.js');
-
-module.exports = {
-    gameState,
-    ports,
-    goods,
-    portInventory,
-    portDistances,
-    seaRoutes,
-    inventorySettings,
-    shipUpgrades,
-    calculateRequiredSupplies,
-    hasEnoughSupplies,
-    consumeSupplies,
-    buySupply,
-    autoSupplyForVoyage,
-    getPortStock,
-    reducePortStock,
-    initializePortInventory,
-    refreshPortInventory,
-    getCargoSpace,
-    getCargoUsed,
-    getPrice,
-    saveGame,
-    loadGame,
-    getSeaRoute,
-    initializeVoyageMap,
-    updateShipPosition,
-    calculateSupplyCost,
-    getCurrentPortName,
-    calculateProfitForPort,
-    getRecommendedGoods,
-    isProfitable,
-    canAffordVoyage,
-    selectDestination,
-    findBestTrade
-};
+} from './src/services/autopilot-service.js';

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "daikoukai-jidai-game",
   "version": "1.0.0",
   "description": "大航海時代 - 冒険と貿易の旅",
+  "type": "module",
   "scripts": {
     "test": "node --test test/*.test.js"
   },

--- a/test/autopilot.test.js
+++ b/test/autopilot.test.js
@@ -1,5 +1,5 @@
-const assert = require('node:assert');
-const { describe, it, beforeEach } = require('node:test');
+import assert from 'node:assert';
+import { describe, it, beforeEach } from 'node:test';
 
 // Mock DOM and window environment
 global.window = {
@@ -32,7 +32,7 @@ global.localStorage = {
 };
 
 // Load game module
-const game = require('../game.js');
+import * as game from '../game.js';
 
 describe('Autopilot functionality', () => {
     beforeEach(() => {

--- a/test/ship-reload.test.js
+++ b/test/ship-reload.test.js
@@ -1,5 +1,5 @@
-const { test } = require('node:test');
-const assert = require('node:assert');
+import { test } from 'node:test';
+import assert from 'node:assert';
 
 // Mock localStorage and DOM APIs
 global.localStorage = {
@@ -55,7 +55,7 @@ global.window = {
 global.localStorage.clear();
 
 // Import game module
-const game = require('../game.js');
+import * as game from '../game.js';
 
 test('東インド会社船でセーブ・ロードしても船が変わらないこと', () => {
     // Clear any existing save data

--- a/test/supply.test.js
+++ b/test/supply.test.js
@@ -1,5 +1,5 @@
-const { test } = require('node:test');
-const assert = require('node:assert');
+import { test } from 'node:test';
+import assert from 'node:assert';
 
 // Mock localStorage and DOM APIs
 global.localStorage = {
@@ -52,7 +52,7 @@ global.window = {
 };
 
 // Import game module
-const game = require('../game.js');
+import * as game from '../game.js';
 
 test('calculateRequiredSupplies - 必要な物資を正しく計算する', () => {
     // Reset game state

--- a/test/voyage-map.test.js
+++ b/test/voyage-map.test.js
@@ -1,5 +1,5 @@
-const { test } = require('node:test');
-const assert = require('node:assert');
+import { test } from 'node:test';
+import assert from 'node:assert';
 
 // Mock DOM APIs for SVG
 const createMockSVGElement = (tagName) => {
@@ -68,7 +68,7 @@ global.window = {
 global.localStorage.clear();
 
 // Import game module
-const game = require('../game.js');
+import * as game from '../game.js';
 
 test('港に正しい座標が定義されている', () => {
     const ports = game.ports;


### PR DESCRIPTION
- package.jsonに"type": "module"を追加してESM形式を有効化
- game.jsをCommonJSからESM形式のre-exportファイルに変換
- すべてのテストファイル(.test.js)をESM形式に変換:
  - require() → import文に変更
  - const → importに変更
- すべてのテスト(30個)が成功することを確認

これにより、.cjsファイルを使用せずに.jsファイルでテストが実行可能になりました。