### PR TITLE
test: 各サービスのテストケースを追加

### DIFF
--- a/test/calculations.test.js
+++ b/test/calculations.test.js
@@ -1,0 +1,382 @@
+import { test, describe, beforeEach } from 'node:test';
+import assert from 'node:assert';
+
+// Mock localStorage and DOM APIs
+global.localStorage = {
+    data: {},
+    getItem(key) {
+        return this.data[key] || null;
+    },
+    setItem(key, value) {
+        this.data[key] = value;
+    },
+    removeItem(key) {
+        delete this.data[key];
+    },
+    clear() {
+        this.data = {};
+    }
+};
+
+global.document = {
+    getElementById: () => ({
+        textContent: '',
+        innerHTML: '',
+        appendChild: () => {},
+        scrollTop: 0,
+        scrollHeight: 0,
+        classList: {
+            add: () => {},
+            remove: () => {}
+        }
+    }),
+    querySelector: () => ({
+        textContent: '',
+        innerHTML: '',
+        appendChild: () => {},
+        style: {}
+    }),
+    createElement: () => ({
+        textContent: '',
+        innerHTML: '',
+        appendChild: () => {},
+        style: {}
+    }),
+    body: {
+        appendChild: () => {}
+    }
+};
+
+global.window = {
+    addEventListener: () => {}
+};
+
+// Import modules
+import { gameState } from '../src/core/game-state.js';
+import { ports, goods, portPrices, portDistances } from '../src/core/constants.js';
+import { initializePortInventory, getPortStock } from '../src/services/port-service.js';
+import { calculateRequiredSupplies } from '../src/services/supply-service.js';
+import {
+    getCurrentPortName,
+    getCargoUsed,
+    getCargoSpace,
+    getPrice,
+    calculateProfitForPort,
+    getRecommendedGoods,
+    isProfitable,
+    canAffordVoyage
+} from '../src/utils/calculations.js';
+
+describe('Calculations Utility', () => {
+    beforeEach(() => {
+        // Reset game state
+        gameState.gold = 5000;
+        gameState.currentPort = 'lisbon';
+        gameState.inventory = {};
+        gameState.ship = {
+            name: 'カラベル船',
+            capacity: 100,
+            speed: 1,
+            crew: 20
+        };
+
+        // Initialize port inventory
+        initializePortInventory();
+    });
+
+    describe('getCurrentPortName', () => {
+        test('現在の港の名前を取得できる', () => {
+            gameState.currentPort = 'lisbon';
+            assert.strictEqual(getCurrentPortName(), 'リスボン');
+        });
+
+        test('各港の名前が正しく取得できる', () => {
+            const portTests = [
+                { id: 'seville', name: 'セビリア' },
+                { id: 'venice', name: 'ヴェネツィア' },
+                { id: 'alexandria', name: 'アレクサンドリア' },
+                { id: 'calicut', name: 'カリカット' },
+                { id: 'malacca', name: 'マラッカ' },
+                { id: 'nagasaki', name: '長崎' }
+            ];
+
+            for (const { id, name } of portTests) {
+                gameState.currentPort = id;
+                assert.strictEqual(getCurrentPortName(), name, `${id}の名前が正しい`);
+            }
+        });
+    });
+
+    describe('getCargoUsed', () => {
+        test('空のインベントリでは0を返す', () => {
+            gameState.inventory = {};
+            assert.strictEqual(getCargoUsed(), 0);
+        });
+
+        test('単一の商品がある場合', () => {
+            gameState.inventory = { wine: 10 };
+            assert.strictEqual(getCargoUsed(), 10);
+        });
+
+        test('複数の商品がある場合', () => {
+            gameState.inventory = { wine: 10, cloth: 20, spices: 5 };
+            assert.strictEqual(getCargoUsed(), 35);
+        });
+
+        test('全ての商品タイプを含む場合', () => {
+            gameState.inventory = {
+                wine: 5,
+                cloth: 5,
+                spices: 5,
+                silk: 5,
+                gold_ore: 5,
+                porcelain: 5,
+                tea: 5,
+                silver: 5,
+                food: 5,
+                water: 5
+            };
+            assert.strictEqual(getCargoUsed(), 50);
+        });
+    });
+
+    describe('getCargoSpace', () => {
+        test('空のインベントリでは船の容量全体が空き', () => {
+            gameState.inventory = {};
+            gameState.ship.capacity = 100;
+            assert.strictEqual(getCargoSpace(), 100);
+        });
+
+        test('一部使用している場合の空き容量', () => {
+            gameState.inventory = { wine: 30 };
+            gameState.ship.capacity = 100;
+            assert.strictEqual(getCargoSpace(), 70);
+        });
+
+        test('満載の場合は0を返す', () => {
+            gameState.inventory = { wine: 100 };
+            gameState.ship.capacity = 100;
+            assert.strictEqual(getCargoSpace(), 0);
+        });
+
+        test('大型船の場合', () => {
+            gameState.inventory = { wine: 100 };
+            gameState.ship.capacity = 500;
+            assert.strictEqual(getCargoSpace(), 400);
+        });
+    });
+
+    describe('getPrice', () => {
+        test('購入価格は基本価格×港の倍率×ランダム係数', () => {
+            gameState.currentPort = 'lisbon';
+            const price = getPrice('wine', true);
+
+            // wine base price = 50, lisbon multiplier = 0.8
+            // Expected range: 50 * 0.8 * 0.9 to 50 * 0.8 * 1.1 = 36 to 44
+            assert.ok(price >= 30 && price <= 60, `価格 ${price} が妥当な範囲内`);
+        });
+
+        test('売却価格は購入価格より低い (80%)', () => {
+            gameState.currentPort = 'lisbon';
+
+            // Multiple runs to account for randomness
+            let buyTotal = 0;
+            let sellTotal = 0;
+            for (let i = 0; i < 100; i++) {
+                buyTotal += getPrice('wine', true);
+                sellTotal += getPrice('wine', false);
+            }
+
+            const avgBuy = buyTotal / 100;
+            const avgSell = sellTotal / 100;
+
+            assert.ok(avgSell < avgBuy, '売却価格は購入価格より低い');
+        });
+
+        test('異なる港での価格差', () => {
+            // Spices are cheap in Calicut, expensive in Lisbon
+            gameState.currentPort = 'calicut';
+            const calicutPrices = [];
+            for (let i = 0; i < 10; i++) {
+                calicutPrices.push(getPrice('spices', true));
+            }
+            const avgCalicut = calicutPrices.reduce((a, b) => a + b, 0) / 10;
+
+            gameState.currentPort = 'lisbon';
+            const lisbonPrices = [];
+            for (let i = 0; i < 10; i++) {
+                lisbonPrices.push(getPrice('spices', true));
+            }
+            const avgLisbon = lisbonPrices.reduce((a, b) => a + b, 0) / 10;
+
+            assert.ok(avgCalicut < avgLisbon, 'カリカットの香辛料はリスボンより安い');
+        });
+
+        test('portIdパラメータで別の港の価格を取得', () => {
+            gameState.currentPort = 'lisbon';
+            const calicutPrice = getPrice('spices', true, 'calicut');
+            const lisbonPrice = getPrice('spices', true, 'lisbon');
+
+            // Calicut has lower multiplier (0.6) for spices than Lisbon (2.1)
+            // Multiple runs to get averages
+            let calicutTotal = 0;
+            let lisbonTotal = 0;
+            for (let i = 0; i < 20; i++) {
+                calicutTotal += getPrice('spices', true, 'calicut');
+                lisbonTotal += getPrice('spices', true, 'lisbon');
+            }
+
+            assert.ok(calicutTotal < lisbonTotal, 'カリカットの方が安い');
+        });
+    });
+
+    describe('calculateProfitForPort', () => {
+        test('利益が出る商品のリストを返す', () => {
+            gameState.currentPort = 'lisbon';
+            const profits = calculateProfitForPort('nagasaki', getPortStock);
+
+            assert.ok(Array.isArray(profits), '配列を返す');
+            for (const item of profits) {
+                assert.ok(item.profitPerUnit > 0, '利益がプラス');
+                assert.ok(item.goodId, 'goodIdがある');
+                assert.ok(item.buyPrice, '購入価格がある');
+                assert.ok(item.sellPrice, '売却価格がある');
+            }
+        });
+
+        test('利益率でソートされている', () => {
+            gameState.currentPort = 'lisbon';
+            const profits = calculateProfitForPort('nagasaki', getPortStock);
+
+            for (let i = 0; i < profits.length - 1; i++) {
+                assert.ok(
+                    profits[i].profitMargin >= profits[i + 1].profitMargin,
+                    '利益率降順でソート'
+                );
+            }
+        });
+
+        test('食糧と水は含まれない', () => {
+            gameState.currentPort = 'lisbon';
+            const profits = calculateProfitForPort('nagasaki', getPortStock);
+
+            const hasFood = profits.some(p => p.goodId === 'food');
+            const hasWater = profits.some(p => p.goodId === 'water');
+
+            assert.strictEqual(hasFood, false, '食糧は含まれない');
+            assert.strictEqual(hasWater, false, '水は含まれない');
+        });
+
+        test('リスボンから長崎への利益商品（ワインが高利益）', () => {
+            gameState.currentPort = 'lisbon';
+            const profits = calculateProfitForPort('nagasaki', getPortStock);
+
+            // Wine should be profitable (Lisbon: 0.8, Nagasaki: 1.8)
+            const wine = profits.find(p => p.goodId === 'wine');
+            assert.ok(wine, 'ワインが利益商品に含まれる');
+            assert.ok(wine.profitMargin > 0, 'ワインの利益率がプラス');
+        });
+    });
+
+    describe('getRecommendedGoods', () => {
+        test('指定した数の商品を返す', () => {
+            gameState.currentPort = 'lisbon';
+            const recommended = getRecommendedGoods('nagasaki', getPortStock, 3);
+
+            assert.ok(recommended.length <= 3, '最大3つ');
+        });
+
+        test('デフォルトで3つの商品を返す', () => {
+            gameState.currentPort = 'lisbon';
+            const recommended = getRecommendedGoods('nagasaki', getPortStock);
+
+            assert.ok(recommended.length <= 3, 'デフォルトは最大3つ');
+        });
+
+        test('利益が出る商品がない場合は空配列', () => {
+            // Set up a scenario where no goods are profitable
+            gameState.currentPort = 'nagasaki';
+            const recommended = getRecommendedGoods('nagasaki', getPortStock); // Same port
+
+            // Same port should have no profitable trades
+            // (might still have some due to buy/sell price difference)
+            assert.ok(Array.isArray(recommended), '配列を返す');
+        });
+    });
+
+    describe('isProfitable', () => {
+        test('利益率10%以上でtrueを返す', () => {
+            gameState.currentPort = 'lisbon';
+            const result = isProfitable('nagasaki', getPortStock);
+
+            // Lisbon to Nagasaki should be profitable
+            assert.strictEqual(typeof result, 'boolean');
+        });
+
+        test('リスボンから長崎は利益的', () => {
+            gameState.currentPort = 'lisbon';
+            const result = isProfitable('nagasaki', getPortStock);
+
+            assert.strictEqual(result, true, 'リスボン→長崎は利益的');
+        });
+    });
+
+    describe('canAffordVoyage', () => {
+        test('十分な資金がある場合', () => {
+            gameState.gold = 5000;
+            gameState.inventory = { food: 50, water: 50 };
+            gameState.currentPort = 'lisbon';
+
+            const result = canAffordVoyage('seville', calculateRequiredSupplies);
+
+            assert.strictEqual(result.canAfford, true, '航海可能');
+            assert.ok(result.hasEnoughGold, '資金十分');
+            assert.ok(result.hasEnoughSpace, '積載量十分');
+        });
+
+        test('資金不足の場合', () => {
+            gameState.gold = 0;
+            gameState.inventory = {};
+            gameState.currentPort = 'lisbon';
+
+            const result = canAffordVoyage('nagasaki', calculateRequiredSupplies);
+
+            assert.strictEqual(result.hasEnoughGold, false, '資金不足');
+        });
+
+        test('必要な物資が返される', () => {
+            gameState.gold = 5000;
+            gameState.inventory = {};
+            gameState.currentPort = 'lisbon';
+
+            const result = canAffordVoyage('seville', calculateRequiredSupplies);
+
+            assert.ok('needFood' in result, 'needFoodがある');
+            assert.ok('needWater' in result, 'needWaterがある');
+            assert.ok('supplyCost' in result, 'supplyCostがある');
+        });
+
+        test('既存の物資がある場合は追加購入が少ない', () => {
+            gameState.inventory = { food: 100, water: 100 };
+            gameState.currentPort = 'lisbon';
+
+            const result = canAffordVoyage('seville', calculateRequiredSupplies);
+
+            assert.strictEqual(result.needFood, 0, '追加食糧不要');
+            assert.strictEqual(result.needWater, 0, '追加水不要');
+        });
+
+        test('長距離航海の物資コスト', () => {
+            gameState.gold = 5000;
+            gameState.inventory = {};
+            gameState.currentPort = 'lisbon';
+
+            const shortResult = canAffordVoyage('seville', calculateRequiredSupplies);
+            const longResult = canAffordVoyage('nagasaki', calculateRequiredSupplies);
+
+            assert.ok(longResult.supplyCost >= shortResult.supplyCost, '長距離は物資が多い');
+        });
+    });
+});
+
+console.log('All calculation tests completed!');

--- a/test/event.test.js
+++ b/test/event.test.js
@@ -1,0 +1,644 @@
+import { test, describe, beforeEach } from 'node:test';
+import assert from 'node:assert';
+
+// Mock localStorage and DOM APIs
+global.localStorage = {
+    data: {},
+    getItem(key) {
+        return this.data[key] || null;
+    },
+    setItem(key, value) {
+        this.data[key] = value;
+    },
+    removeItem(key) {
+        delete this.data[key];
+    },
+    clear() {
+        this.data = {};
+    }
+};
+
+global.document = {
+    getElementById: () => ({
+        textContent: '',
+        innerHTML: '',
+        appendChild: () => {},
+        remove: () => {},
+        scrollTop: 0,
+        scrollHeight: 0,
+        classList: {
+            add: () => {},
+            remove: () => {}
+        },
+        querySelectorAll: () => []
+    }),
+    querySelector: () => ({
+        textContent: '',
+        innerHTML: '',
+        appendChild: () => {},
+        style: {}
+    }),
+    createElement: () => ({
+        textContent: '',
+        innerHTML: '',
+        appendChild: () => {},
+        remove: () => {},
+        style: {},
+        querySelectorAll: () => [],
+        querySelector: () => ({ addEventListener: () => {} })
+    }),
+    body: {
+        appendChild: () => {}
+    }
+};
+
+global.window = {
+    addEventListener: () => {}
+};
+
+// Import modules
+import { gameState } from '../src/core/game-state.js';
+import { RANDOM_EVENTS, TREASURES, RARITY_CONFIG, goods } from '../src/core/constants.js';
+import {
+    setEventUICallbacks,
+    checkForRandomEvent,
+    processEventChoice,
+    getRandomTreasure,
+    addTreasure,
+    useTreasure,
+    applyDurabilityDamage,
+    repairShip,
+    getEffectiveSpeed
+} from '../src/services/event-service.js';
+
+describe('Event Service', () => {
+    beforeEach(() => {
+        // Reset game state
+        gameState.gold = 10000;
+        gameState.currentPort = 'lisbon';
+        gameState.inventory = { wine: 10, spices: 5 };
+        gameState.ship = {
+            name: 'カラベル船',
+            capacity: 100,
+            speed: 1,
+            crew: 20,
+            durability: 100,
+            maxDurability: 100,
+            combatPower: 10,
+            speedBonus: 0
+        };
+        gameState.logs = [];
+        gameState.treasures = {};
+        gameState.activeEffects = {};
+        gameState.statistics = {
+            eventsEncountered: 0,
+            piratesDefeated: 0,
+            castawaysRescued: 0,
+            treasuresFound: 0
+        };
+        gameState.portInvestments = {};
+
+        // Set up mock callbacks
+        setEventUICallbacks(() => {}, () => {});
+    });
+
+    describe('checkForRandomEvent', () => {
+        test('イベントを返すか、nullを返す', () => {
+            // Run multiple times to test randomness
+            let eventCount = 0;
+            let nullCount = 0;
+
+            for (let i = 0; i < 100; i++) {
+                const result = checkForRandomEvent(1);
+                if (result) {
+                    eventCount++;
+                    assert.ok(result.id, 'イベントにIDがある');
+                    assert.ok(result.name, 'イベントに名前がある');
+                } else {
+                    nullCount++;
+                }
+            }
+
+            // Should have some events and some nulls
+            assert.ok(eventCount > 0 || nullCount > 0, 'イベントかnullが返される');
+        });
+
+        test('返されるイベントは有効なイベント定義', () => {
+            for (let i = 0; i < 50; i++) {
+                const result = checkForRandomEvent(1);
+                if (result) {
+                    assert.ok(
+                        Object.keys(RANDOM_EVENTS).includes(result.id),
+                        'イベントIDが有効'
+                    );
+                }
+            }
+        });
+    });
+
+    describe('processEventChoice - Pirate', () => {
+        test('海賊戦で勝利すると報酬を得る（不死鳥の羽あり）', () => {
+            gameState.treasures.phoenixFeather = 1;
+            const initialGold = gameState.gold;
+
+            const result = processEventChoice('pirate', 'fight');
+
+            assert.ok(result.success, '処理成功');
+            assert.ok(result.messages.length > 0, 'メッセージがある');
+            // With phoenix feather, always win
+            assert.ok(gameState.gold > initialGold, '報酬を得る');
+            // Phoenix feather is consumed (becomes 0 or undefined)
+            assert.ok(
+                gameState.treasures.phoenixFeather === 0 ||
+                gameState.treasures.phoenixFeather === undefined,
+                '不死鳥の羽が消費される'
+            );
+        });
+
+        test('海賊に身代金を支払う', () => {
+            const initialGold = gameState.gold;
+
+            const result = processEventChoice('pirate', 'pay');
+
+            assert.ok(result.success, '処理成功');
+            assert.ok(result.goldChange < 0, '資金が減少');
+            assert.ok(gameState.gold < initialGold, '支払いが行われた');
+        });
+
+        test('海賊から逃走を試みる', () => {
+            const result = processEventChoice('pirate', 'flee');
+
+            assert.ok(result.success, '処理成功');
+            assert.ok(result.messages.length > 0, 'メッセージがある');
+        });
+    });
+
+    describe('processEventChoice - Castaway', () => {
+        test('漂流者を救助する', () => {
+            const initialGold = gameState.gold;
+            const initialRescued = gameState.statistics.castawaysRescued;
+
+            const result = processEventChoice('castaway', 'rescue');
+
+            assert.ok(result.success, '処理成功');
+            assert.strictEqual(
+                gameState.statistics.castawaysRescued,
+                initialRescued + 1,
+                '救助カウントが増加'
+            );
+        });
+
+        test('漂流者を無視する', () => {
+            const result = processEventChoice('castaway', 'ignore');
+
+            assert.ok(result.success, '処理成功');
+            assert.ok(result.messages.length > 0, 'メッセージがある');
+        });
+    });
+
+    describe('processEventChoice - Shipwreck', () => {
+        test('沈没船を探索する', () => {
+            const result = processEventChoice('shipwreck', 'explore');
+
+            assert.ok(result.success, '処理成功');
+            assert.ok(result.messages.length > 0, 'メッセージがある');
+        });
+
+        test('沈没船を通り過ぎる', () => {
+            const result = processEventChoice('shipwreck', 'leave');
+
+            assert.ok(result.success, '処理成功');
+            assert.strictEqual(result.goldChange, 0, '資金変化なし');
+        });
+    });
+
+    describe('processEventChoice - CargoLoss', () => {
+        test('嵐で積荷を失う', () => {
+            gameState.inventory = { wine: 50, spices: 30 };
+            const initialDurability = gameState.ship.durability;
+
+            const result = processEventChoice('cargoLoss', 'accept');
+
+            assert.ok(result.success, '処理成功');
+            assert.ok(result.durabilityChange < 0, '耐久度が減少');
+            assert.ok(
+                gameState.ship.durability < initialDurability,
+                '船がダメージを受ける'
+            );
+        });
+    });
+
+    describe('getRandomTreasure', () => {
+        test('お宝オブジェクトを返す', () => {
+            const treasure = getRandomTreasure();
+
+            assert.ok(treasure, 'お宝が返される');
+            assert.ok(treasure.id, 'IDがある');
+            assert.ok(treasure.name, '名前がある');
+            assert.ok(treasure.rarity, 'レアリティがある');
+        });
+
+        test('最小レアリティを指定できる', () => {
+            for (let i = 0; i < 20; i++) {
+                const treasure = getRandomTreasure('rare');
+
+                assert.ok(
+                    ['rare', 'legendary'].includes(treasure.rarity),
+                    `レアリティは${treasure.rarity}でrare以上`
+                );
+            }
+        });
+
+        test('全てのレアリティで取得可能', () => {
+            const rarities = new Set();
+
+            for (let i = 0; i < 100; i++) {
+                const treasure = getRandomTreasure();
+                rarities.add(treasure.rarity);
+            }
+
+            // Should get at least uncommon and rare with enough tries
+            assert.ok(rarities.size >= 2, '複数のレアリティが出現');
+        });
+    });
+
+    describe('addTreasure', () => {
+        test('お宝をインベントリに追加', () => {
+            addTreasure('luckyCharm');
+
+            assert.strictEqual(
+                gameState.treasures.luckyCharm,
+                1,
+                'お宝が追加される'
+            );
+        });
+
+        test('同じお宝を複数追加', () => {
+            addTreasure('ancientCoin');
+            addTreasure('ancientCoin');
+            addTreasure('ancientCoin');
+
+            assert.strictEqual(
+                gameState.treasures.ancientCoin,
+                3,
+                '3個追加される'
+            );
+        });
+
+        test('パッシブ効果のあるお宝は効果が適用される', () => {
+            gameState.activeEffects = {};
+
+            addTreasure('luckyCharm');
+
+            assert.ok(
+                gameState.activeEffects.luckBonus > 0,
+                '幸運ボーナスが適用される'
+            );
+        });
+
+        test('統計が更新される', () => {
+            const initialCount = gameState.statistics.treasuresFound;
+
+            addTreasure('ancientCoin');
+
+            assert.strictEqual(
+                gameState.statistics.treasuresFound,
+                initialCount + 1,
+                '発見数が増加'
+            );
+        });
+    });
+
+    describe('useTreasure', () => {
+        test('使用可能なお宝を使用できる', () => {
+            gameState.treasures.ancientMap = 1;
+            gameState.activeEffects = {};
+
+            const result = useTreasure('ancientMap');
+
+            assert.ok(result.success, '使用成功');
+            assert.ok(result.messages.length > 0, 'メッセージがある');
+            assert.strictEqual(
+                gameState.treasures.ancientMap,
+                undefined,
+                'お宝が消費される'
+            );
+        });
+
+        test('持っていないお宝は使用できない', () => {
+            gameState.treasures = {};
+
+            const result = useTreasure('ancientMap');
+
+            assert.strictEqual(result.success, false, '使用失敗');
+        });
+
+        test('パッシブ効果のお宝は使用できない', () => {
+            gameState.treasures.luckyCharm = 1;
+
+            const result = useTreasure('luckyCharm');
+
+            assert.strictEqual(result.success, false, '使用できない');
+            assert.strictEqual(
+                gameState.treasures.luckyCharm,
+                1,
+                'お宝は残る'
+            );
+        });
+
+        test('人魚の涙で船を完全修復', () => {
+            gameState.treasures.mermaidTear = 1;
+            gameState.ship.durability = 30;
+            gameState.ship.maxDurability = 100;
+
+            const result = useTreasure('mermaidTear');
+
+            assert.ok(result.success, '使用成功');
+            assert.strictEqual(
+                gameState.ship.durability,
+                100,
+                '完全修復'
+            );
+        });
+
+        test('黄金の羅針盤で速度ボーナス', () => {
+            gameState.treasures.goldenCompass = 1;
+            gameState.ship.speedBonus = 0;
+
+            const result = useTreasure('goldenCompass');
+
+            assert.ok(result.success, '使用成功');
+            assert.ok(
+                gameState.ship.speedBonus > 0,
+                '速度ボーナスが付与'
+            );
+        });
+
+        test('王家の冠で大金を得る', () => {
+            gameState.treasures.royalCrown = 1;
+            const initialGold = gameState.gold;
+
+            const result = useTreasure('royalCrown');
+
+            assert.ok(result.success, '使用成功');
+            assert.strictEqual(
+                gameState.gold,
+                initialGold + 50000,
+                '50000G獲得'
+            );
+        });
+    });
+
+    describe('applyDurabilityDamage', () => {
+        test('船に耐久度ダメージを与える', () => {
+            gameState.ship.durability = 100;
+
+            applyDurabilityDamage(30);
+
+            assert.strictEqual(
+                gameState.ship.durability,
+                70,
+                '30ダメージ'
+            );
+        });
+
+        test('耐久度は0未満にならない', () => {
+            gameState.ship.durability = 50;
+
+            applyDurabilityDamage(100);
+
+            assert.strictEqual(
+                gameState.ship.durability,
+                0,
+                '0で止まる'
+            );
+        });
+
+        test('耐久度が低いと警告ログ', () => {
+            gameState.ship.durability = 100;
+            gameState.ship.maxDurability = 100;
+
+            applyDurabilityDamage(80); // Durability becomes 20 (< 30%)
+
+            // Log should be added
+            assert.ok(
+                gameState.ship.durability < gameState.ship.maxDurability * 0.3,
+                '耐久度が危険レベル'
+            );
+        });
+    });
+
+    describe('repairShip', () => {
+        test('造船所がないと修理できない', () => {
+            gameState.portInvestments = {};
+
+            const result = repairShip('lisbon');
+
+            assert.strictEqual(result.success, false, '修理失敗');
+        });
+
+        test('造船所があれば修理できる', () => {
+            gameState.portInvestments = {
+                lisbon: { shipyard: 1 }
+            };
+            gameState.ship.durability = 50;
+            gameState.ship.maxDurability = 100;
+            gameState.gold = 10000;
+
+            const result = repairShip('lisbon');
+
+            assert.ok(result.success, '修理成功');
+            assert.strictEqual(
+                gameState.ship.durability,
+                100,
+                '完全修復'
+            );
+        });
+
+        test('既に完全な状態では修理不要', () => {
+            gameState.portInvestments = {
+                lisbon: { shipyard: 1 }
+            };
+            gameState.ship.durability = 100;
+            gameState.ship.maxDurability = 100;
+
+            const result = repairShip('lisbon');
+
+            assert.strictEqual(result.success, false, '修理不要');
+        });
+
+        test('資金不足では修理できない', () => {
+            gameState.portInvestments = {
+                lisbon: { shipyard: 1 }
+            };
+            gameState.ship.durability = 0;
+            gameState.ship.maxDurability = 100;
+            gameState.gold = 100; // Not enough for full repair (100 * 5 = 500G needed)
+
+            const result = repairShip('lisbon');
+
+            assert.strictEqual(result.success, false, '資金不足');
+        });
+
+        test('修理費用は1ダメージあたり5G', () => {
+            gameState.portInvestments = {
+                lisbon: { shipyard: 1 }
+            };
+            gameState.ship.durability = 80;
+            gameState.ship.maxDurability = 100;
+            gameState.gold = 10000;
+            const initialGold = gameState.gold;
+
+            repairShip('lisbon');
+
+            // 20 damage * 5G = 100G
+            assert.strictEqual(
+                gameState.gold,
+                initialGold - 100,
+                '100G消費'
+            );
+        });
+    });
+
+    describe('getEffectiveSpeed', () => {
+        test('基本速度を返す', () => {
+            gameState.ship.speed = 1;
+            gameState.ship.speedBonus = 0;
+            gameState.ship.durability = 100;
+            gameState.ship.maxDurability = 100;
+
+            const speed = getEffectiveSpeed();
+
+            assert.strictEqual(speed, 1, '基本速度1');
+        });
+
+        test('速度ボーナスが加算される', () => {
+            gameState.ship.speed = 1;
+            gameState.ship.speedBonus = 0.2;
+            gameState.ship.durability = 100;
+            gameState.ship.maxDurability = 100;
+
+            const speed = getEffectiveSpeed();
+
+            assert.strictEqual(speed, 1.2, 'ボーナス込み1.2');
+        });
+
+        test('耐久度が低いと速度低下（30%未満）', () => {
+            gameState.ship.speed = 1;
+            gameState.ship.speedBonus = 0;
+            gameState.ship.durability = 20;
+            gameState.ship.maxDurability = 100;
+
+            const speed = getEffectiveSpeed();
+
+            assert.strictEqual(speed, 0.5, '50%に低下');
+        });
+
+        test('耐久度が低いと速度低下（50%未満）', () => {
+            gameState.ship.speed = 1;
+            gameState.ship.speedBonus = 0;
+            gameState.ship.durability = 40;
+            gameState.ship.maxDurability = 100;
+
+            const speed = getEffectiveSpeed();
+
+            assert.strictEqual(speed, 0.75, '75%に低下');
+        });
+
+        test('耐久度50%以上は通常速度', () => {
+            gameState.ship.speed = 1;
+            gameState.ship.speedBonus = 0;
+            gameState.ship.durability = 60;
+            gameState.ship.maxDurability = 100;
+
+            const speed = getEffectiveSpeed();
+
+            assert.strictEqual(speed, 1, '通常速度');
+        });
+    });
+});
+
+describe('RANDOM_EVENTS definitions', () => {
+    test('全てのイベントに必須フィールドがある', () => {
+        for (const [eventId, event] of Object.entries(RANDOM_EVENTS)) {
+            assert.ok(event.id, `${eventId}にIDがある`);
+            assert.ok(event.name, `${eventId}に名前がある`);
+            assert.ok(event.emoji, `${eventId}に絵文字がある`);
+            assert.ok(event.description, `${eventId}に説明がある`);
+            assert.ok(event.probability, `${eventId}に確率がある`);
+            assert.ok(event.choices, `${eventId}に選択肢がある`);
+            assert.ok(event.choices.length > 0, `${eventId}に選択肢が1つ以上ある`);
+        }
+    });
+
+    test('全ての選択肢に必須フィールドがある', () => {
+        for (const [eventId, event] of Object.entries(RANDOM_EVENTS)) {
+            for (const choice of event.choices) {
+                assert.ok(choice.id, `${eventId}の選択肢にIDがある`);
+                assert.ok(choice.text, `${eventId}の選択肢にテキストがある`);
+                assert.ok(choice.description, `${eventId}の選択肢に説明がある`);
+            }
+        }
+    });
+
+    test('確率の合計が1以下', () => {
+        let totalProbability = 0;
+        for (const event of Object.values(RANDOM_EVENTS)) {
+            totalProbability += event.probability;
+        }
+
+        assert.ok(totalProbability <= 1, `確率合計${totalProbability}は1以下`);
+    });
+});
+
+describe('TREASURES definitions', () => {
+    test('全てのお宝に必須フィールドがある', () => {
+        for (const [treasureId, treasure] of Object.entries(TREASURES)) {
+            assert.ok(treasure.id, `${treasureId}にIDがある`);
+            assert.ok(treasure.name, `${treasureId}に名前がある`);
+            assert.ok(treasure.emoji, `${treasureId}に絵文字がある`);
+            assert.ok(treasure.rarity, `${treasureId}にレアリティがある`);
+            assert.ok(treasure.description, `${treasureId}に説明がある`);
+            assert.ok(treasure.effect, `${treasureId}に効果がある`);
+            assert.strictEqual(
+                typeof treasure.usable,
+                'boolean',
+                `${treasureId}にusableフラグがある`
+            );
+        }
+    });
+
+    test('全てのレアリティが有効', () => {
+        const validRarities = Object.keys(RARITY_CONFIG);
+
+        for (const [treasureId, treasure] of Object.entries(TREASURES)) {
+            assert.ok(
+                validRarities.includes(treasure.rarity),
+                `${treasureId}のレアリティ${treasure.rarity}は有効`
+            );
+        }
+    });
+
+    test('効果タイプが有効', () => {
+        const validTypes = [
+            'bonus_gold_next_trade',
+            'permanent_speed_bonus',
+            'luck_bonus',
+            'pirate_protection',
+            'trade_bonus',
+            'full_repair',
+            'guaranteed_victory',
+            'sell_value',
+            'cursed'
+        ];
+
+        for (const [treasureId, treasure] of Object.entries(TREASURES)) {
+            assert.ok(
+                validTypes.includes(treasure.effect.type),
+                `${treasureId}の効果タイプ${treasure.effect.type}は有効`
+            );
+        }
+    });
+});
+
+console.log('All event service tests completed!');

--- a/test/port.test.js
+++ b/test/port.test.js
@@ -1,0 +1,356 @@
+import { test, describe, beforeEach } from 'node:test';
+import assert from 'node:assert';
+
+// Mock localStorage and DOM APIs
+global.localStorage = {
+    data: {},
+    getItem(key) {
+        return this.data[key] || null;
+    },
+    setItem(key, value) {
+        this.data[key] = value;
+    },
+    removeItem(key) {
+        delete this.data[key];
+    },
+    clear() {
+        this.data = {};
+    }
+};
+
+global.document = {
+    getElementById: () => ({
+        textContent: '',
+        innerHTML: '',
+        appendChild: () => {},
+        scrollTop: 0,
+        scrollHeight: 0,
+        classList: {
+            add: () => {},
+            remove: () => {}
+        }
+    }),
+    querySelector: () => ({
+        textContent: '',
+        innerHTML: '',
+        appendChild: () => {},
+        style: {}
+    }),
+    createElement: () => ({
+        textContent: '',
+        innerHTML: '',
+        appendChild: () => {},
+        style: {}
+    }),
+    body: {
+        appendChild: () => {}
+    }
+};
+
+global.window = {
+    addEventListener: () => {}
+};
+
+// Import modules
+import { portInventory } from '../src/core/game-state.js';
+import { ports, inventorySettings, goods } from '../src/core/constants.js';
+import {
+    initializePortInventory,
+    refreshPortInventory,
+    getPortStock,
+    reducePortStock
+} from '../src/services/port-service.js';
+
+describe('Port Service', () => {
+    beforeEach(() => {
+        // Clear port inventory
+        for (const portId in portInventory) {
+            delete portInventory[portId];
+        }
+    });
+
+    describe('initializePortInventory', () => {
+        test('全ての港の在庫が初期化される', () => {
+            initializePortInventory();
+
+            for (const portId in ports) {
+                assert.ok(portInventory[portId], `${portId}の在庫が存在する`);
+            }
+        });
+
+        test('港のサイズに応じた最大在庫が設定される', () => {
+            initializePortInventory();
+
+            // 長崎 (small) - maxStock: 30
+            assert.strictEqual(
+                portInventory.nagasaki.wine,
+                inventorySettings.small.maxStock,
+                '長崎は30個'
+            );
+
+            // リスボン (large) - maxStock: 100
+            assert.strictEqual(
+                portInventory.lisbon.wine,
+                inventorySettings.large.maxStock,
+                'リスボンは100個'
+            );
+
+            // ヴェネツィア (very_large) - maxStock: 150
+            assert.strictEqual(
+                portInventory.venice.wine,
+                inventorySettings.very_large.maxStock,
+                'ヴェネツィアは150個'
+            );
+
+            // アレクサンドリア (medium) - maxStock: 60
+            assert.strictEqual(
+                portInventory.alexandria.wine,
+                inventorySettings.medium.maxStock,
+                'アレクサンドリアは60個'
+            );
+        });
+
+        test('全ての商品タイプが初期化される', () => {
+            initializePortInventory();
+
+            for (const goodId in goods) {
+                assert.ok(
+                    portInventory.lisbon[goodId] !== undefined,
+                    `${goodId}が初期化されている`
+                );
+            }
+        });
+    });
+
+    describe('getPortStock', () => {
+        beforeEach(() => {
+            initializePortInventory();
+        });
+
+        test('存在する商品の在庫を取得できる', () => {
+            const stock = getPortStock('lisbon', 'wine');
+            assert.strictEqual(stock, 100, 'リスボンのワイン在庫');
+        });
+
+        test('存在しない港は0を返す', () => {
+            const stock = getPortStock('unknown_port', 'wine');
+            assert.strictEqual(stock, 0, '存在しない港は0');
+        });
+
+        test('存在しない商品は0を返す', () => {
+            const stock = getPortStock('lisbon', 'unknown_good');
+            assert.strictEqual(stock, 0, '存在しない商品は0');
+        });
+
+        test('各港サイズの在庫を確認', () => {
+            const portSizeTests = [
+                { port: 'nagasaki', expected: 30 },     // small
+                { port: 'alexandria', expected: 60 },  // medium
+                { port: 'calicut', expected: 60 },     // medium
+                { port: 'malacca', expected: 60 },     // medium
+                { port: 'lisbon', expected: 100 },     // large
+                { port: 'seville', expected: 100 },    // large
+                { port: 'venice', expected: 150 }      // very_large
+            ];
+
+            for (const { port, expected } of portSizeTests) {
+                assert.strictEqual(
+                    getPortStock(port, 'wine'),
+                    expected,
+                    `${port}の在庫は${expected}`
+                );
+            }
+        });
+    });
+
+    describe('reducePortStock', () => {
+        beforeEach(() => {
+            initializePortInventory();
+        });
+
+        test('在庫を減らせる', () => {
+            const initialStock = getPortStock('lisbon', 'wine');
+            reducePortStock('lisbon', 'wine', 10);
+            assert.strictEqual(
+                getPortStock('lisbon', 'wine'),
+                initialStock - 10,
+                '10個減少'
+            );
+        });
+
+        test('在庫は0未満にならない', () => {
+            reducePortStock('lisbon', 'wine', 200); // More than stock
+            assert.strictEqual(
+                getPortStock('lisbon', 'wine'),
+                0,
+                '0以下にはならない'
+            );
+        });
+
+        test('存在しない港でも在庫を作成して減らせる', () => {
+            // Clear and don't initialize
+            for (const portId in portInventory) {
+                delete portInventory[portId];
+            }
+
+            reducePortStock('new_port', 'wine', 10);
+            assert.strictEqual(
+                getPortStock('new_port', 'wine'),
+                0,
+                '0になる（負にならない）'
+            );
+        });
+
+        test('複数回減らせる', () => {
+            const initialStock = getPortStock('lisbon', 'wine');
+            reducePortStock('lisbon', 'wine', 5);
+            reducePortStock('lisbon', 'wine', 5);
+            reducePortStock('lisbon', 'wine', 5);
+
+            assert.strictEqual(
+                getPortStock('lisbon', 'wine'),
+                initialStock - 15,
+                '15個減少'
+            );
+        });
+    });
+
+    describe('refreshPortInventory', () => {
+        beforeEach(() => {
+            initializePortInventory();
+        });
+
+        test('時間経過で在庫が回復する', () => {
+            // Reduce stock first
+            reducePortStock('lisbon', 'wine', 50);
+            const reducedStock = getPortStock('lisbon', 'wine');
+
+            // Refresh with 1 day passed
+            refreshPortInventory(1);
+
+            const refreshedStock = getPortStock('lisbon', 'wine');
+
+            // large port refreshRate = 8
+            assert.strictEqual(
+                refreshedStock,
+                reducedStock + 8,
+                '1日で8個回復'
+            );
+        });
+
+        test('最大在庫を超えない', () => {
+            // Stock is already at max
+            const initialStock = getPortStock('lisbon', 'wine');
+
+            refreshPortInventory(100); // Many days
+
+            assert.strictEqual(
+                getPortStock('lisbon', 'wine'),
+                initialStock,
+                '最大在庫を超えない'
+            );
+        });
+
+        test('港のサイズに応じた回復率', () => {
+            // Reduce stock at different sized ports
+            reducePortStock('nagasaki', 'wine', 20);    // small: refreshRate 3
+            reducePortStock('alexandria', 'wine', 40); // medium: refreshRate 5
+            reducePortStock('lisbon', 'wine', 50);     // large: refreshRate 8
+            reducePortStock('venice', 'wine', 100);    // very_large: refreshRate 12
+
+            refreshPortInventory(1);
+
+            // Check each port recovered correctly
+            assert.strictEqual(
+                getPortStock('nagasaki', 'wine'),
+                30 - 20 + 3,
+                '長崎: 3個回復'
+            );
+            assert.strictEqual(
+                getPortStock('alexandria', 'wine'),
+                60 - 40 + 5,
+                'アレクサンドリア: 5個回復'
+            );
+            assert.strictEqual(
+                getPortStock('lisbon', 'wine'),
+                100 - 50 + 8,
+                'リスボン: 8個回復'
+            );
+            assert.strictEqual(
+                getPortStock('venice', 'wine'),
+                150 - 100 + 12,
+                'ヴェネツィア: 12個回復'
+            );
+        });
+
+        test('複数日の回復', () => {
+            reducePortStock('lisbon', 'wine', 50);
+            const reducedStock = getPortStock('lisbon', 'wine');
+
+            refreshPortInventory(5); // 5 days
+
+            // large port refreshRate = 8, so 8 * 5 = 40
+            assert.strictEqual(
+                getPortStock('lisbon', 'wine'),
+                reducedStock + 40,
+                '5日で40個回復'
+            );
+        });
+
+        test('全ての港が同時に回復する', () => {
+            // Reduce stock at multiple ports
+            for (const portId in ports) {
+                reducePortStock(portId, 'wine', 20);
+            }
+
+            refreshPortInventory(1);
+
+            // All ports should have recovered
+            for (const portId in ports) {
+                const portSize = ports[portId].size;
+                const refreshRate = inventorySettings[portSize].refreshRate;
+                const maxStock = inventorySettings[portSize].maxStock;
+                const expected = Math.min(maxStock, maxStock - 20 + refreshRate);
+
+                assert.strictEqual(
+                    getPortStock(portId, 'wine'),
+                    expected,
+                    `${portId}が正しく回復`
+                );
+            }
+        });
+
+        test('全ての商品が回復する', () => {
+            // Reduce multiple goods
+            for (const goodId in goods) {
+                reducePortStock('lisbon', goodId, 30);
+            }
+
+            refreshPortInventory(1);
+
+            // All goods should have recovered
+            for (const goodId in goods) {
+                assert.strictEqual(
+                    getPortStock('lisbon', goodId),
+                    100 - 30 + 8,
+                    `${goodId}が回復`
+                );
+            }
+        });
+
+        test('0日経過では回復しない', () => {
+            reducePortStock('lisbon', 'wine', 50);
+            const reducedStock = getPortStock('lisbon', 'wine');
+
+            refreshPortInventory(0);
+
+            assert.strictEqual(
+                getPortStock('lisbon', 'wine'),
+                reducedStock,
+                '0日では回復しない'
+            );
+        });
+    });
+});
+
+console.log('All port service tests completed!');

--- a/test/trade.test.js
+++ b/test/trade.test.js
@@ -1,0 +1,313 @@
+import { test, describe, beforeEach } from 'node:test';
+import assert from 'node:assert';
+
+// Mock localStorage and DOM APIs
+global.localStorage = {
+    data: {},
+    getItem(key) {
+        return this.data[key] || null;
+    },
+    setItem(key, value) {
+        this.data[key] = value;
+    },
+    removeItem(key) {
+        delete this.data[key];
+    },
+    clear() {
+        this.data = {};
+    }
+};
+
+// Track DOM operations for testing
+const domOperations = {
+    classChanges: [],
+    reset() {
+        this.classChanges = [];
+    }
+};
+
+global.document = {
+    getElementById: (id) => ({
+        textContent: '',
+        innerHTML: '',
+        appendChild: () => {},
+        scrollTop: 0,
+        scrollHeight: 0,
+        classList: {
+            add: (cls) => { domOperations.classChanges.push({ action: 'add', class: cls }); },
+            remove: (cls) => { domOperations.classChanges.push({ action: 'remove', class: cls }); }
+        }
+    }),
+    querySelector: () => ({
+        textContent: '',
+        innerHTML: '',
+        appendChild: () => {},
+        style: {}
+    }),
+    createElement: () => ({
+        textContent: '',
+        innerHTML: '',
+        appendChild: () => {},
+        style: {}
+    }),
+    body: {
+        appendChild: () => {}
+    }
+};
+
+global.window = {
+    addEventListener: () => {}
+};
+
+// Import modules
+import { gameState } from '../src/core/game-state.js';
+import { goods, shipUpgrades } from '../src/core/constants.js';
+import { initializePortInventory, getPortStock, reducePortStock } from '../src/services/port-service.js';
+import { getPrice, getCargoUsed, getCargoSpace } from '../src/utils/calculations.js';
+import { buyGood, buyAllGood, sellGood, sellAllGood, upgradeShip, setUICallbacks } from '../src/services/trade-service.js';
+
+// Mock updateAll function
+let updateAllCalled = false;
+function mockUpdateAll() {
+    updateAllCalled = true;
+}
+
+describe('Trade Service', () => {
+    beforeEach(() => {
+        // Reset game state
+        gameState.gold = 5000;
+        gameState.currentPort = 'lisbon';
+        gameState.inventory = {};
+        gameState.ship = {
+            name: 'カラベル船',
+            capacity: 100,
+            speed: 1,
+            crew: 20
+        };
+        gameState.logs = [];
+
+        // Initialize port inventory
+        initializePortInventory();
+
+        // Reset tracking
+        updateAllCalled = false;
+        domOperations.reset();
+
+        // Set UI callbacks
+        setUICallbacks(mockUpdateAll);
+    });
+
+    describe('buyGood', () => {
+        test('商品を1個購入できる', () => {
+            const initialGold = gameState.gold;
+            const initialStock = getPortStock('lisbon', 'wine');
+
+            buyGood('wine');
+
+            assert.strictEqual(gameState.inventory.wine, 1, '商品が追加される');
+            assert.ok(gameState.gold < initialGold, '資金が減少する');
+            assert.strictEqual(getPortStock('lisbon', 'wine'), initialStock - 1, '港の在庫が減少する');
+            assert.ok(updateAllCalled, 'UI更新が呼ばれる');
+        });
+
+        test('資金不足の場合は購入できない', () => {
+            gameState.gold = 1; // Very low gold
+            const initialGold = gameState.gold;
+
+            buyGood('silk'); // Expensive item
+
+            assert.strictEqual(gameState.inventory.silk, undefined, '商品が追加されない');
+            assert.strictEqual(gameState.gold, initialGold, '資金が変わらない');
+        });
+
+        test('積載量が一杯の場合は購入できない', () => {
+            gameState.inventory = { wine: 100 }; // Ship is full
+            const initialGold = gameState.gold;
+
+            buyGood('cloth');
+
+            assert.strictEqual(gameState.inventory.cloth, undefined, '商品が追加されない');
+            assert.strictEqual(gameState.gold, initialGold, '資金が変わらない');
+        });
+
+        test('在庫がない場合は購入できない', () => {
+            // Reduce port stock to 0
+            const stock = getPortStock('lisbon', 'wine');
+            reducePortStock('lisbon', 'wine', stock);
+
+            const initialGold = gameState.gold;
+
+            buyGood('wine');
+
+            assert.strictEqual(gameState.inventory.wine, undefined, '商品が追加されない');
+            assert.strictEqual(gameState.gold, initialGold, '資金が変わらない');
+        });
+    });
+
+    describe('buyAllGood', () => {
+        test('資金制限で購入可能な最大数を購入', () => {
+            gameState.gold = 500;
+            const price = getPrice('wine', true);
+            const maxByMoney = Math.floor(gameState.gold / price);
+
+            buyAllGood('wine');
+
+            assert.ok(gameState.inventory.wine > 0, '商品が購入される');
+            assert.ok(gameState.inventory.wine <= maxByMoney, '資金制限内で購入');
+        });
+
+        test('積載量制限で購入可能な最大数を購入', () => {
+            gameState.gold = 50000; // Enough money
+            gameState.inventory = { silk: 90 }; // Only 10 spaces left
+
+            buyAllGood('wine');
+
+            const totalCargo = getCargoUsed();
+            assert.ok(totalCargo <= gameState.ship.capacity, '積載量を超えない');
+        });
+
+        test('在庫制限で購入可能な最大数を購入', () => {
+            gameState.gold = 50000;
+            // Reduce port stock
+            reducePortStock('lisbon', 'wine', getPortStock('lisbon', 'wine') - 5);
+
+            buyAllGood('wine');
+
+            assert.ok(gameState.inventory.wine <= 5, '在庫以上は購入しない');
+        });
+
+        test('購入できない場合はエラーメッセージ', () => {
+            gameState.gold = 1;
+            const initialGold = gameState.gold;
+
+            buyAllGood('silk');
+
+            assert.strictEqual(gameState.gold, initialGold, '資金が変わらない');
+        });
+    });
+
+    describe('sellGood', () => {
+        test('商品を1個売却できる', () => {
+            gameState.inventory = { wine: 10 };
+            const initialGold = gameState.gold;
+
+            sellGood('wine');
+
+            assert.strictEqual(gameState.inventory.wine, 9, '商品が減少する');
+            assert.ok(gameState.gold > initialGold, '資金が増加する');
+            assert.ok(updateAllCalled, 'UI更新が呼ばれる');
+        });
+
+        test('持っていない商品は売却できない', () => {
+            gameState.inventory = {};
+            const initialGold = gameState.gold;
+
+            sellGood('wine');
+
+            assert.strictEqual(gameState.gold, initialGold, '資金が変わらない');
+        });
+
+        test('売却時にゴールドアニメーションが実行される', () => {
+            gameState.inventory = { wine: 10 };
+            domOperations.reset();
+
+            sellGood('wine');
+
+            const goldAnimation = domOperations.classChanges.find(
+                op => op.action === 'add' && op.class === 'gold-animation'
+            );
+            assert.ok(goldAnimation, 'gold-animationクラスが追加される');
+        });
+    });
+
+    describe('sellAllGood', () => {
+        test('全ての商品を売却できる', () => {
+            gameState.inventory = { wine: 20 };
+            const initialGold = gameState.gold;
+
+            sellAllGood('wine');
+
+            assert.strictEqual(gameState.inventory.wine, 0, '全て売却される');
+            assert.ok(gameState.gold > initialGold, '資金が増加する');
+        });
+
+        test('複数個売却時の合計金額が正しい', () => {
+            gameState.inventory = { wine: 10 };
+            const initialGold = gameState.gold;
+            const price = getPrice('wine', false);
+            const expectedRevenue = price * 10;
+
+            sellAllGood('wine');
+
+            // Price has randomness, so check if revenue is reasonable
+            const actualRevenue = gameState.gold - initialGold;
+            assert.ok(actualRevenue > 0, '収益がある');
+        });
+
+        test('持っていない商品は売却できない', () => {
+            gameState.inventory = {};
+            const initialGold = gameState.gold;
+
+            sellAllGood('wine');
+
+            assert.strictEqual(gameState.gold, initialGold, '資金が変わらない');
+        });
+    });
+
+    describe('upgradeShip', () => {
+        test('十分な資金があれば船をアップグレードできる', () => {
+            gameState.gold = 10000;
+            gameState.inventory = {};
+
+            upgradeShip(1); // キャラック船
+
+            assert.strictEqual(gameState.ship.name, 'キャラック船', '船がアップグレードされる');
+            assert.strictEqual(gameState.ship.capacity, 200, '積載量が増加');
+            assert.strictEqual(gameState.gold, 5000, '費用が差し引かれる');
+        });
+
+        test('資金不足の場合はアップグレードできない', () => {
+            gameState.gold = 1000;
+            const initialShip = { ...gameState.ship };
+
+            upgradeShip(1); // キャラック船 (cost: 5000)
+
+            assert.strictEqual(gameState.ship.name, initialShip.name, '船が変わらない');
+        });
+
+        test('積荷が新しい船の容量を超える場合はアップグレードできない', () => {
+            gameState.gold = 10000;
+            gameState.ship = shipUpgrades[1]; // キャラック船 (capacity: 200)
+            gameState.inventory = { wine: 150 }; // 150 items
+
+            upgradeShip(0); // カラベル船 (capacity: 100) - downgrade
+
+            // Should not downgrade because cargo exceeds capacity
+            assert.strictEqual(gameState.ship.capacity, 200, '船が変わらない');
+        });
+
+        test('ガレオン船へのアップグレード', () => {
+            gameState.gold = 20000;
+            gameState.inventory = {};
+
+            upgradeShip(2); // ガレオン船
+
+            assert.strictEqual(gameState.ship.name, 'ガレオン船', '船がアップグレードされる');
+            assert.strictEqual(gameState.ship.capacity, 300, '積載量が300');
+            assert.strictEqual(gameState.ship.speed, 1.5, '速度が1.5');
+        });
+
+        test('東インド会社船へのアップグレード', () => {
+            gameState.gold = 60000;
+            gameState.inventory = {};
+
+            upgradeShip(3); // 東インド会社船
+
+            assert.strictEqual(gameState.ship.name, '東インド会社船', '船がアップグレードされる');
+            assert.strictEqual(gameState.ship.capacity, 500, '積載量が500');
+            assert.strictEqual(gameState.ship.speed, 2, '速度が2');
+        });
+    });
+});
+
+console.log('All trade tests completed!');


### PR DESCRIPTION
- trade.test.js: 売買機能（buyGood, sellGood, buyAllGood, sellAllGood, upgradeShip）のテスト
- calculations.test.js: 計算ユーティリティ（getPrice, calculateProfitForPort, canAffordVoyage等）のテスト
- port.test.js: 港サービス（initializePortInventory, refreshPortInventory, getPortStock, reducePortStock）のテスト
- event.test.js: イベントサービス（ランダムイベント処理、お宝、船耐久度、修理）のテスト

テスト数: 31 → 137 (106テスト追加)