### PR TITLE
docs(openspec): add version display feature spec

### DIFF
--- a/openspec/changes/display-version/proposal.md
+++ b/openspec/changes/display-version/proposal.md
@@ -1,0 +1,67 @@
+# Proposal: Display Version Information on Game Screen
+
+## Overview
+
+Display the game version number on the game screen header for better user experience and debugging support.
+
+## Current State
+
+- Version is defined in `package.json` as `"version": "1.0.0"`
+- No version information is currently visible to users
+- Debugging and support issues are harder to track without visible version info
+
+## Proposed Solution
+
+### Display Location
+
+Add version information to the game header, displayed next to or below the game title:
+
+```
+🚢 大航海時代 🚢
+未知なる海へ、富と栄光を求めて
+v1.0.0
+```
+
+### Implementation Approach
+
+1. **Build-time injection**: Inject version from `package.json` during build/bundling
+2. **Runtime display**: Show version in the header area of `index.html`
+
+Since this project uses vanilla ES modules without a build step, we will:
+- Create a `src/core/version.js` file that exports the version
+- Update this file manually or via script when version changes
+- Display the version in the game UI
+
+### Alternative Considered
+
+- Reading `package.json` at runtime via fetch: Rejected due to unnecessary network request and potential CORS issues in some environments
+
+## Expected Benefits
+
+1. **User Experience**: Users can easily identify which version they are playing
+2. **Support**: Easier to troubleshoot issues when users can report their version
+3. **Testing**: Clear verification that correct version is deployed
+
+## Impact Scope
+
+### Files to Create
+- `src/core/version.js` - Version constant
+
+### Files to Modify
+- `index.html` - Add version display element
+- `src/game.js` - Import and display version on init
+
+### No Changes Required
+- Game logic, services, or other UI components
+
+## Risk Assessment
+
+**Risk Level**: Low
+
+- No impact on game functionality
+- Simple, isolated change
+- Easy to test and verify
+
+## References
+
+- [package.json](../../../package.json) - Source of version number

--- a/openspec/changes/display-version/specs/version-display.md
+++ b/openspec/changes/display-version/specs/version-display.md
@@ -1,0 +1,111 @@
+# Spec: Version Display
+
+## Summary
+
+Display the application version from `package.json` on the game screen header.
+
+## Requirements
+
+### Functional Requirements
+
+1. **Version Source**
+   - Version MUST be sourced from `package.json` `version` field
+   - Current version: `1.0.0`
+
+2. **Display Location**
+   - Version MUST be displayed in the game header area
+   - Position: Below the subtitle "未知なる海へ、富と栄光を求めて"
+   - Format: `v{major}.{minor}.{patch}` (e.g., `v1.0.0`)
+
+3. **Styling**
+   - Font size: Smaller than subtitle (approximately 0.8em)
+   - Color: Semi-transparent to not distract from main content
+   - Alignment: Center-aligned with header
+
+### Non-Functional Requirements
+
+1. **Performance**
+   - No runtime network requests to fetch version
+   - Version should be available immediately on page load
+
+2. **Maintainability**
+   - Version should be defined in a single source file
+   - Easy to update when releasing new versions
+
+## Technical Design
+
+### New File: `src/core/version.js`
+
+```javascript
+// Version information - keep in sync with package.json
+export const VERSION = '1.0.0';
+```
+
+### Modify: `index.html`
+
+Add version display element in header:
+
+```html
+<header>
+    <h1>🚢 大航海時代 🚢</h1>
+    <p class="subtitle">未知なる海へ、富と栄光を求めて</p>
+    <p id="version-display" class="version"></p>
+</header>
+```
+
+### Modify: `src/game.js`
+
+Import and display version on initialization:
+
+```javascript
+import { VERSION } from './core/version.js';
+
+function initGame() {
+    // Display version
+    const versionElement = document.getElementById('version-display');
+    if (versionElement) {
+        versionElement.textContent = `v${VERSION}`;
+    }
+
+    // ... existing init code
+}
+```
+
+### Modify: `style.css`
+
+Add styling for version display:
+
+```css
+.version {
+    font-size: 0.8em;
+    color: rgba(255, 255, 255, 0.6);
+    margin-top: 5px;
+}
+```
+
+## Test Cases
+
+### TC-1: Version is displayed on page load
+
+**Given**: User opens the game
+**When**: Page finishes loading
+**Then**: Version "v1.0.0" is visible in the header area
+
+### TC-2: Version format is correct
+
+**Given**: Version in version.js is "1.0.0"
+**When**: Displayed on screen
+**Then**: Shows "v1.0.0" (with 'v' prefix)
+
+### TC-3: Version is styled appropriately
+
+**Given**: Version is displayed
+**When**: User views the header
+**Then**: Version text is smaller and less prominent than subtitle
+
+## Acceptance Criteria
+
+- [ ] Version displays correctly in header
+- [ ] Version matches value in `src/core/version.js`
+- [ ] Styling does not interfere with existing header elements
+- [ ] No console errors related to version display

--- a/openspec/changes/display-version/tasks.md
+++ b/openspec/changes/display-version/tasks.md
@@ -1,0 +1,48 @@
+# Tasks: Display Version Feature
+
+## Overview
+
+Implementation tasks for displaying version information on the game screen.
+
+## Tasks
+
+### Phase 1: Core Implementation
+
+- [ ] **Task 1.1**: Create `src/core/version.js`
+  - Export VERSION constant with value from package.json
+  - File location: `src/core/version.js`
+
+- [ ] **Task 1.2**: Update `index.html`
+  - Add `<p id="version-display" class="version"></p>` in header section
+  - Place after subtitle element
+
+- [ ] **Task 1.3**: Update `src/game.js`
+  - Import VERSION from `./core/version.js`
+  - Add version display logic in `initGame()` function
+
+### Phase 2: Styling
+
+- [ ] **Task 2.1**: Add CSS styles
+  - Add `.version` class to `style.css`
+  - Style: smaller font, semi-transparent, centered
+
+### Phase 3: Testing
+
+- [ ] **Task 3.1**: Manual verification
+  - Open game in browser
+  - Verify version displays correctly
+  - Verify styling is appropriate
+
+- [ ] **Task 3.2**: Add unit test (optional)
+  - Test VERSION export from version.js
+  - Test format matches expected pattern
+
+## Dependencies
+
+- None (standalone feature)
+
+## Estimated Scope
+
+- Files to create: 1
+- Files to modify: 3
+- Lines of code: ~20


### PR DESCRIPTION
## Summary

Add OpenSpec change proposal to display version information on the game screen header.

## Purpose

This is a simple, low-risk feature designed to test the automated spec implementation workflow:
- Minimal code changes required (~20 lines)
- Isolated scope (no impact on game logic)
- Easy to verify

## Spec Contents

- **proposal.md**: Feature rationale, approach, and risk assessment
- **specs/version-display.md**: Detailed technical specification with test cases
- **tasks.md**: Implementation task breakdown

## Feature Overview

Display `v1.0.0` in the game header below the subtitle, sourced from `package.json`.

## Next Steps

When this PR is merged, the automated spec implementation workflow should trigger and create an implementation PR.