### PR TITLE
fix(ci): use PAT for issue creation to trigger Claude Assistant

### DIFF
--- a/.github/workflows/spec-implement.yml
+++ b/.github/workflows/spec-implement.yml
@@ -78,7 +78,9 @@ jobs:
       - name: Create implementation issue
         if: steps.detect.outputs.skip != 'true'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # PATを使用することで、作成されたIssueが別のワークフロー(Claude Assistant)をトリガーできる
+          # GITHUB_TOKENだとセキュリティ制限により別ワークフローがトリガーされない
+          GH_TOKEN: ${{ secrets.PAT }}
           FEATURE: ${{ steps.detect.outputs.feature_name }}
           SPEC_PATH: ${{ steps.detect.outputs.spec_path }}
           COMMIT_SHA: ${{ github.sha }}


### PR DESCRIPTION
## Summary

Use PAT (Personal Access Token) instead of GITHUB_TOKEN for creating implementation issues.

## Problem

GitHub's security restrictions prevent workflows triggered by `GITHUB_TOKEN` from triggering other workflows. This means when `spec-implement.yml` creates an issue, the `claude-assistant.yml` workflow is not triggered.

## Solution

Change `GH_TOKEN` from `secrets.GITHUB_TOKEN` to `secrets.PAT`. Issues created with PAT will trigger the Claude Assistant workflow as expected.

## Prerequisites

- `PAT` secret must be configured in repository settings
- PAT requires `Issues: Read and Write` permission

## Test Plan

1. Merge this PR
2. Close and reopen Issue #75 (or create new spec)
3. Verify Claude Assistant workflow is triggered