### PR TITLE
fix(ci): add id-token permission for Claude Assistant

### DIFF
--- a/.github/workflows/claude-assistant.yml
+++ b/.github/workflows/claude-assistant.yml
@@ -21,6 +21,7 @@ permissions:
   contents: write
   pull-requests: write
   issues: write
+  id-token: write
 
 jobs:
   claude-response:
@@ -52,7 +53,7 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
 
           # auto-implementラベル付きIssueの場合の追加指示
-          prompt: |
+          custom_instructions: |
             # プロジェクト固有の指示
 
             ## 実装時の注意事項


### PR DESCRIPTION
## Summary

Fix Claude Assistant workflow failing with OIDC token error.

## Changes

1. Add `id-token: write` permission required by `claude-code-action`
2. Change deprecated `prompt` to `custom_instructions`

## Error Fixed

```
Could not fetch an OIDC token. Did you remember to add `id-token: write` to your workflow permissions?
```

## Test Plan

1. Merge this PR
2. Comment `@claude` on Issue #75
3. Verify workflow runs successfully