### PR TITLE
fix(ci): allow gh CLI for automatic PR creation

### DIFF
--- a/.github/workflows/claude-assistant.yml
+++ b/.github/workflows/claude-assistant.yml
@@ -61,6 +61,7 @@ jobs:
             - Specに書かれた範囲のみ実装してください
             - 不明点があればIssueにコメントして確認してください
             - 実装完了後は `npm test` を実行してテストを確認してください
+            - テストが通ったら `gh pr create` でPRを作成してください
 
             ## コーディング規約
             - コメントは日本語で記述
@@ -73,5 +74,6 @@ jobs:
             2. このIssue/PRにコメントで質問
             3. @${{ github.repository_owner }} をメンションして通知
 
-          allowed_tools: "Bash,Read,Write,Edit,Glob,Grep"
+          # gh CLIを許可してPR作成を可能にする
+          allowed_tools: "Bash,Read,Write,Edit,Glob,Grep,Bash(gh:*)"
           timeout_minutes: 30


### PR DESCRIPTION
## Summary

Allow Claude Assistant to automatically create PRs after implementing features.

## Changes

1. Add `Bash(gh:*)` to `allowed_tools` - enables `gh pr create` command
2. Add instruction to create PR after tests pass

## Problem

Previously, Claude could implement features and push to a branch, but couldn't create PRs automatically because `gh` CLI wasn't in the allowed tools list.

## Test Plan

1. Merge this PR
2. Create a new spec and merge it
3. Verify Claude Assistant creates both the implementation AND the PR automatically