### PR TITLE
docs(openspec): add log timestamp feature spec

### DIFF
--- a/openspec/changes/log-timestamp/proposal.md
+++ b/openspec/changes/log-timestamp/proposal.md
@@ -1,0 +1,47 @@
+# Proposal: Add Timestamp to Game Log
+
+## Overview
+
+Add timestamp prefix to each log entry in the game log for better tracking.
+
+## Current State
+
+- Log entries show only the message text
+- No timestamp information available
+- Hard to track when events occurred
+
+## Proposed Solution
+
+Add `[HH:MM]` timestamp prefix to each log entry.
+
+Example:
+```
+[14:30] Arrived at Lisbon port
+[14:31] Bought 10 silk for 500 gold
+```
+
+## Implementation
+
+Modify the `addLog` function in `src/utils/logger.js` to prepend current time.
+
+## Expected Benefits
+
+1. Better event tracking
+2. Useful for debugging
+3. Improved user experience
+
+## Impact Scope
+
+### Files to Modify
+- `src/utils/logger.js` - Add timestamp to addLog function
+
+### No Changes Required
+- HTML, CSS, or other JavaScript files
+
+## Risk Assessment
+
+**Risk Level**: Very Low
+
+- Single file change
+- No impact on game logic
+- Simple string formatting

--- a/openspec/changes/log-timestamp/specs/timestamp.md
+++ b/openspec/changes/log-timestamp/specs/timestamp.md
@@ -1,0 +1,67 @@
+# Spec: Log Timestamp
+
+## Summary
+
+Add timestamp prefix to game log entries.
+
+## Requirements
+
+### Functional Requirements
+
+1. **Timestamp Format**
+   - Format: `[HH:MM]` (24-hour format)
+   - Example: `[09:05]`, `[14:30]`, `[23:59]`
+
+2. **Display Location**
+   - Prepend to each log message
+   - Format: `[HH:MM] {message}`
+
+3. **Time Source**
+   - Use current browser time (local time)
+
+## Technical Design
+
+### Modify: `src/utils/logger.js`
+
+Update the `addLog` function:
+
+```javascript
+export function addLog(message) {
+    const now = new Date();
+    const hours = String(now.getHours()).padStart(2, '0');
+    const minutes = String(now.getMinutes()).padStart(2, '0');
+    const timestamp = `[${hours}:${minutes}]`;
+
+    // Prepend timestamp to message
+    const logMessage = `${timestamp} ${message}`;
+
+    // ... existing log display logic
+}
+```
+
+## Test Cases
+
+### TC-1: Timestamp format is correct
+
+**Given**: Current time is 14:05
+**When**: addLog("Test message") is called
+**Then**: Log shows "[14:05] Test message"
+
+### TC-2: Hours are zero-padded
+
+**Given**: Current time is 09:05
+**When**: addLog("Morning event") is called
+**Then**: Log shows "[09:05] Morning event"
+
+### TC-3: Minutes are zero-padded
+
+**Given**: Current time is 14:03
+**When**: addLog("Event") is called
+**Then**: Log shows "[14:03] Event"
+
+## Acceptance Criteria
+
+- [ ] Timestamp appears before each log message
+- [ ] Format is `[HH:MM]` with zero-padding
+- [ ] Existing log functionality unchanged
+- [ ] No console errors

--- a/openspec/changes/log-timestamp/tasks.md
+++ b/openspec/changes/log-timestamp/tasks.md
@@ -1,0 +1,32 @@
+# Tasks: Log Timestamp Feature
+
+## Overview
+
+Add timestamp to game log entries.
+
+## Tasks
+
+### Phase 1: Implementation
+
+- [ ] **Task 1.1**: Update `src/utils/logger.js`
+  - Add timestamp generation logic
+  - Prepend `[HH:MM]` to log messages
+
+### Phase 2: Testing
+
+- [ ] **Task 2.1**: Run existing tests
+  - Ensure no regressions
+
+- [ ] **Task 2.2**: Manual verification
+  - Open game in browser
+  - Perform actions that generate logs
+  - Verify timestamps appear correctly
+
+## Dependencies
+
+- None
+
+## Estimated Scope
+
+- Files to modify: 1
+- Lines of code: ~5


### PR DESCRIPTION
## Summary

Add spec for log timestamp feature - prepend `[HH:MM]` to game log entries.

## Spec Contents

- **proposal.md**: Feature overview
- **specs/timestamp.md**: Technical specification
- **tasks.md**: Implementation tasks

## Scope

- Files to modify: 1 (`src/utils/logger.js`)
- Lines of code: ~5
- Risk: Very Low

## Expected Automation

When this PR is merged:
1. Spec Implementation workflow creates Issue with `auto-implement` label
2. Claude Assistant triggers automatically
3. Claude implements the feature and creates PR