### PR TITLE
feat: ログにタイムスタンプを追加

### DIFF
--- a/src/utils/logger.js
+++ b/src/utils/logger.js
@@ -2,14 +2,23 @@ import { gameState } from '../core/game-state.js';
 
 // Add log message to game log
 export function addLog(message) {
+    // タイムスタンプを生成
+    const now = new Date();
+    const hours = String(now.getHours()).padStart(2, '0');
+    const minutes = String(now.getMinutes()).padStart(2, '0');
+    const timestamp = `[${hours}:${minutes}]`;
+    
+    // タイムスタンプをメッセージに追加
+    const timestampedMessage = `${timestamp} ${message}`;
+
     const logDiv = document.getElementById('game-log');
     const p = document.createElement('p');
-    p.textContent = message;
+    p.textContent = timestampedMessage;
     logDiv.appendChild(p);
     logDiv.scrollTop = logDiv.scrollHeight;
 
-    // Save log to gameState
-    gameState.logs.push(message);
+    // Save log to gameState with timestamp
+    gameState.logs.push(timestampedMessage);
     // Keep only last 50 logs to prevent excessive storage
     if (gameState.logs.length > 50) {
         gameState.logs.shift();


### PR DESCRIPTION
## Summary

ゲームログに [HH:MM] 形式のタイムスタンプを追加

## 実装内容

- `src/utils/logger.js` の addLog 関数を修正
- 24時間形式、ゼロパディング対応
- 例: `[14:30] Arrived at Lisbon port`

## Spec

- Spec: `openspec/changes/log-timestamp/`
- Issue: #81

Closes #81