### PR TITLE
fix(ci): add id-token permission and use custom_instructions in review workflow

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -7,6 +7,7 @@ on:
 permissions:
   contents: read
   pull-requests: write
+  id-token: write
 
 jobs:
   review:
@@ -36,7 +37,8 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
 
-          prompt: |
+          # custom_instructions を使用 (prompt は deprecated)
+          custom_instructions: |
             # PRレビュー依頼
 
             このPRをレビューしてください。


### PR DESCRIPTION
## Summary
Fix Claude Code Review workflow to work properly.

## Changes
- Add `id-token: write` permission (required for OIDC authentication)
- Change `prompt` to `custom_instructions` (prompt is deprecated)