### PR TITLE
fix(ci): add concurrency control to reduce token usage

### DIFF
--- a/.github/workflows/claude-assistant.yml
+++ b/.github/workflows/claude-assistant.yml
@@ -25,6 +25,12 @@ permissions:
   issues: write
   id-token: write
 
+# 同じPR/Issueへの重複実行を防止 (トークン節約)
+# cancel-in-progress: false で複数Proposalが同時マージされても全て実行される
+concurrency:
+  group: claude-assistant-${{ github.event.issue.number || github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: false
+
 jobs:
   # ジョブ1: @claudeメンションやauto-implementラベル付きIssueに対応
   claude-response:

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -9,6 +9,12 @@ permissions:
   pull-requests: write
   id-token: write
 
+# 同じPRへの重複レビューを防止 (トークン節約)
+# cancel-in-progress: false で複数PRが同時作成されても全てレビューされる
+concurrency:
+  group: claude-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
 jobs:
   review:
     # ドラフトPRはスキップ、botが作ったPRも対象


### PR DESCRIPTION
## Summary

Add concurrency groups to Claude workflows to prevent duplicate executions and reduce API token consumption.

## Changes

- **claude-assistant.yml**: Added concurrency group by Issue/PR number
- **claude-review.yml**: Added concurrency group by PR number

## Configuration

```yaml
concurrency:
  group: claude-assistant-${{ github.event.issue.number || github.event.pull_request.number || github.run_id }}
  cancel-in-progress: false
```

- `cancel-in-progress: false` ensures all requests are eventually processed (queued, not cancelled)
- Different PRs/Issues can run in parallel
- Same PR/Issue runs are serialized to prevent duplicate work

## Problem Solved

PR #104 showed 20+ workflow runs triggered by streaming comment updates. With this fix, duplicate triggers on the same PR will be queued instead of running simultaneously, reducing Claude API token usage.